### PR TITLE
FR: Virtual Mappings und tangierende Issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,9 +25,16 @@ MQTT_PASSWORD=my-mqtt-password
 # - MAPPING_X_FIELD_POSITIVE: the name of the InfluxDB field to write to for positive values (optional)
 # - MAPPING_X_FIELD_NEGATIVE: the name of the InfluxDB field to write to for negative values (optional)
 # - MAPPING_X_TYPE: the data type of the field. It can be one of integer, float, string or boolean
+# - MAPPING_X_MIN: the minimum allowed value - a lower value is ignored instead of written (optional)
+# - MAPPING_X_MAX: the maximum allowed value - a higher value is ignored instead of written (optional)
+# - MAPPING_X_NULL_TO_ZERO: set to "true" to convert a missing/NULL value to 0 instead of
+#   ignoring it (optional)
 # - MAPPING_X_JSON_KEY: the key in the JSON payload to extract the value from (optional, only for JSON payloads)
 # - MAPPING_X_JSON_PATH: the JSONPath in the JSON payload to extract the value from (optional, only for JSON payloads)
 # - MAPPING_X_JSON_FORMULA: a formula to calculate the value from the JSON payload (optional, only for JSON payloads)
+# - MAPPING_X_FORMULA: a formula to calculate the value from the plain (non-JSON) message itself,
+#   using the `{value}` placeholder (optional). Also used, without a MAPPING_X_TOPIC, to define a
+#   virtual mapping (see below)
 # - MAPPING_X_MAX_AGE: how many seconds this mapping's value stays valid for use in a virtual
 #   mapping's formula, after which it's treated as unknown instead of stale (optional)
 # - MAPPING_X_AGGREGATE_INTERVAL: instead of writing every single value to InfluxDB, collect
@@ -35,11 +42,14 @@ MQTT_PASSWORD=my-mqtt-password
 #   (optional, useful to throttle down high-frequency topics)
 # - MAPPING_X_SKIP_WRITE: set to "true" to process this mapping's value (e.g. to keep it
 #   available for MAX_AGE tracking and virtual mapping formulas), without ever writing it to
-#   InfluxDB itself (optional, useful for raw sensors that only feed a virtual mapping)
+#   InfluxDB itself (optional, useful for raw sensors that only feed a virtual mapping). Since
+#   it's never written, MAPPING_X_FIELD/MEASUREMENT (and their _POSITIVE/_NEGATIVE variants)
+#   become optional too - only MAPPING_X_TOPIC and MAPPING_X_TYPE are still needed
 # - MAPPING_X_DEDUP: set to "true" to skip writing a value that's unchanged from the last one
-#   written. A repeated zero is suppressed indefinitely (written once, then ignored until it
-#   changes); a repeated non-zero value is still written periodically (see
-#   MAPPING_X_HEARTBEAT_INTERVAL below), to show that the sender is still active (optional)
+#   written. A repeated zero (or "false", for boolean) is suppressed indefinitely (written once,
+#   then ignored until it changes); any other repeated value (including strings, which have no
+#   zero equivalent) is still written periodically (see MAPPING_X_HEARTBEAT_INTERVAL below), to
+#   show that the sender is still active (optional)
 # - MAPPING_X_HEARTBEAT_INTERVAL: how many seconds a repeated non-zero value may be suppressed
 #   by MAPPING_X_DEDUP before it's written again anyway (optional, defaults to 60)
 #
@@ -164,6 +174,9 @@ MQTT_PASSWORD=my-mqtt-password
 #   MAPPING_8_SKIP_WRITE=true
 #   MAPPING_9_SKIP_WRITE=true
 #
+# (you could also remove MAPPING_8_MEASUREMENT/FIELD and MAPPING_9_MEASUREMENT/FIELD entirely at
+# this point, since a mapping with SKIP_WRITE=true never needs an InfluxDB destination)
+#
 # If a sensor stops sending updates (e.g. due to a connection loss), its last known value would
 # otherwise be reused forever by any virtual mapping that references it - silently producing
 # values calculated from outdated data. To avoid that, set MAPPING_X_MAX_AGE (in seconds) on the
@@ -190,12 +203,12 @@ MQTT_PASSWORD=my-mqtt-password
 # means the value actually expired.
 #
 # Mapping that skips writing unchanged values, to avoid flooding InfluxDB with duplicates:
-#   MAPPING_12_TOPIC=my/leak-sensor/state
-#   MAPPING_12_MEASUREMENT=Leak
-#   MAPPING_12_FIELD=detected
-#   MAPPING_12_TYPE=boolean
-#   MAPPING_12_DEDUP=true
-#   MAPPING_12_HEARTBEAT_INTERVAL=60
+#   MAPPING_13_TOPIC=my/leak-sensor/state
+#   MAPPING_13_MEASUREMENT=Leak
+#   MAPPING_13_FIELD=detected
+#   MAPPING_13_TYPE=boolean
+#   MAPPING_13_DEDUP=true
+#   MAPPING_13_HEARTBEAT_INTERVAL=60
 #
 # As long as the value keeps arriving as "false" (or 0, for numeric types), it's written once and
 # then ignored - no further signal is needed. Once it becomes "true" (or non-zero), that change is

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ MQTT_PASSWORD=my-mqtt-password
 # - MAPPING_X_AGGREGATE_INTERVAL: instead of writing every single value to InfluxDB, collect
 #   values for this many seconds and write their average once the interval has elapsed
 #   (optional, useful to throttle down high-frequency topics)
+# - MAPPING_X_SKIP_WRITE: set to "true" to process this mapping's value (e.g. to keep it
+#   available for MAX_AGE tracking and virtual mapping formulas), without ever writing it to
+#   InfluxDB itself (optional, useful for raw sensors that only feed a virtual mapping)
 #
 #
 # Here are some examples of mappings:
@@ -147,6 +150,13 @@ MQTT_PASSWORD=my-mqtt-password
 # You can chain virtual mappings, i.e. reference a virtual mapping from another virtual mapping.
 # As long as one of the referenced values hasn't been received yet, the virtual mapping is
 # ignored (or defaults to 0, if MAPPING_X_NULL_TO_ZERO=true is set).
+#
+# If you only care about the calculated total and don't want the raw sensors cluttering
+# InfluxDB, add MAPPING_X_SKIP_WRITE=true to MAPPING_8 and MAPPING_9 above - their values are
+# still tracked in memory and used by the total_power formula, they're just never written
+# themselves:
+#   MAPPING_8_SKIP_WRITE=true
+#   MAPPING_9_SKIP_WRITE=true
 #
 # If a sensor stops sending updates (e.g. due to a connection loss), its last known value would
 # otherwise be reused forever by any virtual mapping that references it - silently producing

--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,14 @@ MQTT_PASSWORD=my-mqtt-password
 # and whether the value was never received at all, or received but too old, e.g.:
 #   Formula for total_power could not be evaluated
 #   (MAPPING_8 [my/washing-machine/power]: last received 145s ago, exceeds MAX_AGE of 120s)
+#
+# Formulas can also use comparisons (==, !=, >, <, >=, <=) and IF(), including across mappings.
+# As with arithmetic, the result stays unresolved as long as any referenced mapping is missing
+# or outdated - a comparison never treats "unknown" as a real value to compare against:
+#   MAPPING_11_MEASUREMENT=Household
+#   MAPPING_11_FIELD=washer_and_dryer_different
+#   MAPPING_11_TYPE=integer
+#   MAPPING_11_FORMULA="IF({MAPPING_8} != {MAPPING_9}, {MAPPING_8}, 0)"
 # The "never received" case fires immediately (e.g. right after a restart, when the in-memory
 # cache is still empty) and is unrelated to MAX_AGE - only "last received ... exceeds MAX_AGE ..."
 # means the value actually expired.

--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,11 @@ MQTT_PASSWORD=my-mqtt-password
 # never been received (see above), so the virtual mapping stops being written to InfluxDB
 # instead of continuing with a stale input:
 #   MAPPING_8_MAX_AGE=120
+#
+# Whenever a virtual mapping can't be calculated, a warning is logged naming exactly which
+# mapping(s) are missing or outdated, together with their topic (or field, for virtual mappings),
+# e.g. "Formula for total_power could not be evaluated (missing or outdated: MAPPING_8
+# [my/washing-machine/power])".
 
 MAPPING_0_TOPIC=senec/0/ENERGY/GUI_INVERTER_POWER
 MAPPING_0_MEASUREMENT=PV

--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@ MQTT_PASSWORD=my-mqtt-password
 # - MAPPING_X_JSON_FORMULA: a formula to calculate the value from the JSON payload (optional, only for JSON payloads)
 # - MAPPING_X_MAX_AGE: how many seconds this mapping's value stays valid for use in a virtual
 #   mapping's formula, after which it's treated as unknown instead of stale (optional)
+# - MAPPING_X_AGGREGATE_INTERVAL: instead of writing every single value to InfluxDB, collect
+#   values for this many seconds and write their average once the interval has elapsed
+#   (optional, useful to throttle down high-frequency topics)
 #
 #
 # Here are some examples of mappings:
@@ -107,6 +110,19 @@ MQTT_PASSWORD=my-mqtt-password
 #   MAPPING_7_FORMULA="{value} * 1000"
 #
 # (just use the `{value}` placeholder to reference the value)
+#
+# Mapping that throttles a high-frequency topic down to one write every 5 seconds:
+#   MAPPING_12_TOPIC=my/fast-changing/power
+#   MAPPING_12_MEASUREMENT=Fast
+#   MAPPING_12_FIELD=power
+#   MAPPING_12_TYPE=float
+#   MAPPING_12_AGGREGATE_INTERVAL=5
+#
+# If messages for this topic arrive every second, they're collected in memory and only their
+# average is written to InfluxDB once every 5 seconds, instead of writing every single value.
+# The 5-second window starts with the first value received, and a new window begins right after
+# each write - so writes happen every ~5s as long as new values keep arriving, not on a fixed
+# wall-clock schedule.
 #
 # Virtual mapping (calculates a value from other mappings, without its own MQTT topic):
 #   MAPPING_8_TOPIC=my/washing-machine/power

--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,8 @@ MQTT_PASSWORD=my-mqtt-password
 # - MAPPING_X_JSON_KEY: the key in the JSON payload to extract the value from (optional, only for JSON payloads)
 # - MAPPING_X_JSON_PATH: the JSONPath in the JSON payload to extract the value from (optional, only for JSON payloads)
 # - MAPPING_X_JSON_FORMULA: a formula to calculate the value from the JSON payload (optional, only for JSON payloads)
+# - MAPPING_X_MAX_AGE: how many seconds this mapping's value stays valid for use in a virtual
+#   mapping's formula, after which it's treated as unknown instead of stale (optional)
 #
 #
 # Here are some examples of mappings:
@@ -129,6 +131,14 @@ MQTT_PASSWORD=my-mqtt-password
 # You can chain virtual mappings, i.e. reference a virtual mapping from another virtual mapping.
 # As long as one of the referenced values hasn't been received yet, the virtual mapping is
 # ignored (or defaults to 0, if MAPPING_X_NULL_TO_ZERO=true is set).
+#
+# If a sensor stops sending updates (e.g. due to a connection loss), its last known value would
+# otherwise be reused forever by any virtual mapping that references it - silently producing
+# values calculated from outdated data. To avoid that, set MAPPING_X_MAX_AGE (in seconds) on the
+# source mapping. Once its last value is older than that, it's treated the same as if it had
+# never been received (see above), so the virtual mapping stops being written to InfluxDB
+# instead of continuing with a stale input:
+#   MAPPING_8_MAX_AGE=120
 
 MAPPING_0_TOPIC=senec/0/ENERGY/GUI_INVERTER_POWER
 MAPPING_0_MEASUREMENT=PV

--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,12 @@ MQTT_PASSWORD=my-mqtt-password
 # - MAPPING_X_SKIP_WRITE: set to "true" to process this mapping's value (e.g. to keep it
 #   available for MAX_AGE tracking and virtual mapping formulas), without ever writing it to
 #   InfluxDB itself (optional, useful for raw sensors that only feed a virtual mapping)
+# - MAPPING_X_DEDUP: set to "true" to skip writing a value that's unchanged from the last one
+#   written. A repeated zero is suppressed indefinitely (written once, then ignored until it
+#   changes); a repeated non-zero value is still written periodically (see
+#   MAPPING_X_HEARTBEAT_INTERVAL below), to show that the sender is still active (optional)
+# - MAPPING_X_HEARTBEAT_INTERVAL: how many seconds a repeated non-zero value may be suppressed
+#   by MAPPING_X_DEDUP before it's written again anyway (optional, defaults to 60)
 #
 #
 # Here are some examples of mappings:
@@ -182,6 +188,21 @@ MQTT_PASSWORD=my-mqtt-password
 # The "never received" case fires immediately (e.g. right after a restart, when the in-memory
 # cache is still empty) and is unrelated to MAX_AGE - only "last received ... exceeds MAX_AGE ..."
 # means the value actually expired.
+#
+# Mapping that skips writing unchanged values, to avoid flooding InfluxDB with duplicates:
+#   MAPPING_12_TOPIC=my/leak-sensor/state
+#   MAPPING_12_MEASUREMENT=Leak
+#   MAPPING_12_FIELD=detected
+#   MAPPING_12_TYPE=boolean
+#   MAPPING_12_DEDUP=true
+#   MAPPING_12_HEARTBEAT_INTERVAL=60
+#
+# As long as the value keeps arriving as "false" (or 0, for numeric types), it's written once and
+# then ignored - no further signal is needed. Once it becomes "true" (or non-zero), that change is
+# always written immediately, and then re-written every 60 seconds for as long as it stays "true" -
+# so a monitoring dashboard can tell "still true" apart from "sender has gone silent".
+# This applies per written field, so a MEASUREMENT_POSITIVE/NEGATIVE mapping is deduplicated
+# independently for each of the two fields.
 
 MAPPING_0_TOPIC=senec/0/ENERGY/GUI_INVERTER_POWER
 MAPPING_0_MEASUREMENT=PV

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,8 @@ MQTT_PASSWORD=my-mqtt-password
 #
 # Allowed environment variables for each mapping are:
 #
-# - MAPPING_X_TOPIC: the MQTT topic to subscribe to
+# - MAPPING_X_TOPIC: the MQTT topic to subscribe to. Leave this out to define a "virtual"
+#   mapping, which calculates its value from other mappings instead of an MQTT topic (see below)
 # - MAPPING_X_MEASUREMENT: the name of the InfluxDB measurement to write to
 # - MAPPING_X_MEASUREMENT_POSITIVE: the name of the InfluxDB measurement to write to for positive values (optional)
 # - MAPPING_X_MEASUREMENT_NEGATIVE: the name of the InfluxDB measurement to write to for negative values (optional)
@@ -104,6 +105,30 @@ MQTT_PASSWORD=my-mqtt-password
 #   MAPPING_7_FORMULA="{value} * 1000"
 #
 # (just use the `{value}` placeholder to reference the value)
+#
+# Virtual mapping (calculates a value from other mappings, without its own MQTT topic):
+#   MAPPING_8_TOPIC=my/washing-machine/power
+#   MAPPING_8_MEASUREMENT=Washer
+#   MAPPING_8_FIELD=power
+#   MAPPING_8_TYPE=float
+#
+#   MAPPING_9_TOPIC=my/dryer/power
+#   MAPPING_9_MEASUREMENT=Dryer
+#   MAPPING_9_FIELD=power
+#   MAPPING_9_TYPE=float
+#
+#   MAPPING_10_MEASUREMENT=Household
+#   MAPPING_10_FIELD=total_power
+#   MAPPING_10_TYPE=float
+#   MAPPING_10_FORMULA="{MAPPING_8} + {MAPPING_9}"
+#
+# This calculates `total_power` as the sum of `power` (Washer) and `power` (Dryer), whenever
+# either of them changes. The collector keeps track of the latest value of every mapping in
+# memory, and re-evaluates every virtual mapping each time a message is received - so make sure
+# to reference the mapping by its index (`MAPPING_8`, `MAPPING_9`, ...), not by its field name.
+# You can chain virtual mappings, i.e. reference a virtual mapping from another virtual mapping.
+# As long as one of the referenced values hasn't been received yet, the virtual mapping is
+# ignored (or defaults to 0, if MAPPING_X_NULL_TO_ZERO=true is set).
 
 MAPPING_0_TOPIC=senec/0/ENERGY/GUI_INVERTER_POWER
 MAPPING_0_MEASUREMENT=PV

--- a/.env.example
+++ b/.env.example
@@ -141,9 +141,13 @@ MQTT_PASSWORD=my-mqtt-password
 #   MAPPING_8_MAX_AGE=120
 #
 # Whenever a virtual mapping can't be calculated, a warning is logged naming exactly which
-# mapping(s) are missing or outdated, together with their topic (or field, for virtual mappings),
-# e.g. "Formula for total_power could not be evaluated (missing or outdated: MAPPING_8
-# [my/washing-machine/power])".
+# mapping(s) are missing or outdated, together with their topic (or field, for virtual mappings)
+# and whether the value was never received at all, or received but too old, e.g.:
+#   Formula for total_power could not be evaluated
+#   (MAPPING_8 [my/washing-machine/power]: last received 145s ago, exceeds MAX_AGE of 120s)
+# The "never received" case fires immediately (e.g. right after a restart, when the in-memory
+# cache is still empty) and is unrelated to MAX_AGE - only "last received ... exceeds MAX_AGE ..."
+# means the value actually expired.
 
 MAPPING_0_TOPIC=senec/0/ENERGY/GUI_INVERTER_POWER
 MAPPING_0_MEASUREMENT=PV

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -1,0 +1,72 @@
+name: Build branch image
+
+# Builds and pushes a Docker image for feature branches to this fork's own
+# GHCR namespace (ghcr.io/<owner>/mqtt-collector), using the built-in
+# GITHUB_TOKEN. This is separate from push.yml, which only builds on
+# `develop` and version tags and pushes to ghcr.io/solectrus/mqtt-collector.
+
+on:
+  push:
+    branches-ignore:
+      - develop
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set ENV values
+        run: |
+          echo "COMMIT_VERSION=$(git describe --always --abbrev=7)" >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            COMMIT_VERSION=${{ env.COMMIT_VERSION }}
+          cache-from: type=gha,scope=branch-build
+          cache-to: type=gha,mode=max,scope=branch-build
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Note: For a SENEC device there is a dedicated [senec-collector](https://github.c
 
 The Docker image supports multiple platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7`
 
+## Resilience against InfluxDB outages
+
+On startup, the collector waits (up to 12 seconds) for InfluxDB to become reachable before it starts subscribing to MQTT.
+
+While running, incoming MQTT messages are always received and converted immediately - they're never blocked by a slow or unreachable InfluxDB. Instead, they're queued in memory and written by a separate background process. If a write fails (e.g. because InfluxDB is temporarily unreachable), the batch stays queued and is retried automatically every 5 seconds, keeping its original measurement time - so once InfluxDB is reachable again, the backlog is delivered with the timestamps of when the values actually arrived, not when they were finally written.
+
+Note: this in-memory queue is lost if the container is restarted while InfluxDB is still unreachable.
+
 ## Development
 
 For development you need a recent Ruby setup. On a Mac, I recommend [rbenv](https://github.com/rbenv/rbenv).

--- a/app.rb
+++ b/app.rb
@@ -41,4 +41,12 @@ else
   logger.info "\n"
 end
 
+if mapper.virtual_mappings.any?
+  logger.info "Calculating #{mapper.virtual_mappings.length} virtual mapping(s):"
+  mapper.virtual_mappings.each do |mapping|
+    logger.info "- #{mapper.formatted_virtual_mapping(mapping)}"
+  end
+  logger.info "\n"
+end
+
 Loop.new(config:).start

--- a/compose.yml
+++ b/compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   mqtt-collector:
-    image: ghcr.io/solectrus/mqtt-collector:latest
+    image: ghcr.io/patricknitsch/mqtt-collector:claude-collector-mehrwertberechnung-s8ntzo
     build:
       context: .
       dockerfile: Dockerfile

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -202,23 +202,30 @@ class Config
         validate_mapping!(index, :skip_write, allow_list: %w[true false])
       end
 
-      if mapping[:field_positive] || mapping[:field_negative]
-        validate_mapping!(index, :field_positive)
-        validate_mapping!(index, :field_negative)
-        validate_mapping!(index, :measurement_positive)
-        validate_mapping!(index, :measurement_negative)
+      validate_destination!(mapping, index)
+    end
+  end
 
-        validate_mapping!(index, :field, present: false)
-        validate_mapping!(index, :measurement, present: false)
-      else
-        validate_mapping!(index, :field)
-        validate_mapping!(index, :measurement)
+  # A mapping that's never written to InfluxDB doesn't need a destination
+  def validate_destination!(mapping, index)
+    return if mapping[:skip_write] == 'true'
 
-        validate_mapping!(index, :field_negative, present: false)
-        validate_mapping!(index, :field_positive, present: false)
-        validate_mapping!(index, :measurement_positive, present: false)
-        validate_mapping!(index, :measurement_negative, present: false)
-      end
+    if mapping[:field_positive] || mapping[:field_negative]
+      validate_mapping!(index, :field_positive)
+      validate_mapping!(index, :field_negative)
+      validate_mapping!(index, :measurement_positive)
+      validate_mapping!(index, :measurement_negative)
+
+      validate_mapping!(index, :field, present: false)
+      validate_mapping!(index, :measurement, present: false)
+    else
+      validate_mapping!(index, :field)
+      validate_mapping!(index, :measurement)
+
+      validate_mapping!(index, :field_negative, present: false)
+      validate_mapping!(index, :field_positive, present: false)
+      validate_mapping!(index, :measurement_positive, present: false)
+      validate_mapping!(index, :measurement_negative, present: false)
     end
   end
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -202,6 +202,10 @@ class Config
         validate_mapping!(index, :skip_write, allow_list: %w[true false])
       end
 
+      if mapping[:dedup]
+        validate_mapping!(index, :dedup, allow_list: %w[true false])
+      end
+
       validate_destination!(mapping, index)
     end
   end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -198,6 +198,10 @@ class Config
         validate_mapping!(index, :null_to_zero, allow_list: %w[true false])
       end
 
+      if mapping[:skip_write]
+        validate_mapping!(index, :skip_write, allow_list: %w[true false])
+      end
+
       if mapping[:field_positive] || mapping[:field_negative]
         validate_mapping!(index, :field_positive)
         validate_mapping!(index, :field_negative)

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -183,7 +183,15 @@ class Config
 
   def validate_mappings!
     mappings.each_with_index do |mapping, index|
-      validate_mapping!(index, :topic)
+      if virtual_mapping?(mapping)
+        validate_mapping!(index, :formula)
+        validate_mapping!(index, :json_key, present: false)
+        validate_mapping!(index, :json_path, present: false)
+        validate_mapping!(index, :json_formula, present: false)
+      else
+        validate_mapping!(index, :topic)
+      end
+
       validate_mapping!(index, :type, allow_list: MAPPING_TYPES)
 
       if mapping[:null_to_zero]
@@ -208,6 +216,10 @@ class Config
         validate_mapping!(index, :measurement_negative, present: false)
       end
     end
+  end
+
+  def virtual_mapping?(mapping)
+    mapping[:topic].nil? || mapping[:topic].strip == ''
   end
 
   def validate_mapping!(index, key, present: true, allow_list: nil)

--- a/lib/evaluator.rb
+++ b/lib/evaluator.rb
@@ -25,8 +25,18 @@ class Evaluator
     expression.scan(/{(.*?)}/).flatten
   end
 
+  # Only bind variables that actually have a value. Dentaku's comparison
+  # operators (==, !=) happily compare against an explicit nil instead of
+  # raising, so a bound-but-nil variable would silently be treated as a real,
+  # distinct value rather than "unknown" - unlike arithmetic operators, which
+  # do raise (and get rescued below into an overall nil result). Leaving the
+  # variable out entirely makes Dentaku treat it as unbound, which errors out
+  # (rescued into nil) consistently for every operator.
   def extract_values_from_data(vars)
-    vars.to_h { |var| [normalized_variable(var), value(var)] }
+    vars.filter_map do |var|
+      val = value(var)
+      [normalized_variable(var), val] unless val.nil?
+    end.to_h
   end
 
   def value(variable)

--- a/lib/flux_writer.rb
+++ b/lib/flux_writer.rb
@@ -7,6 +7,10 @@ class FluxWriter
 
   attr_reader :config
 
+  def ready?
+    influx_client.ping.status == 'ok'
+  end
+
   def push(records, time:)
     write_api.write(
       data: points(records, time:),

--- a/lib/influx_push.rb
+++ b/lib/influx_push.rb
@@ -6,25 +6,52 @@ class InfluxPush
 
   def_delegators :config, :logger
 
-  def initialize(config:)
+  def initialize(config:, queue:, retry_delay: 5)
     @config = config
+    @queue = queue
+    @retry_delay = retry_delay
     @flux_writer = FluxWriter.new(config)
   end
 
-  attr_reader :config, :flux_writer
+  attr_reader :config, :queue, :retry_delay, :flux_writer
 
-  def call(records, time:, retries: nil, retry_delay: 5)
-    retry_count = 0
-    begin
-      flux_writer.push(records, time:)
-    rescue StandardError => e
-      logger.error "Error while pushing to InfluxDB: #{e.message}"
-      retry_count += 1
+  def ready?
+    flux_writer.ready?
+  end
 
-      raise e if retries && retry_count > retries
-
-      sleep(retry_delay)
-      retry
+  # Push batches from the queue to InfluxDB, one at a time, for as long as
+  # the queue is open. If InfluxDB is temporarily unreachable, the batch is
+  # put back into the queue and retried later instead of being dropped - it
+  # keeps its original measurement time, so a late write still lands at the
+  # point in time the values were actually received.
+  def run
+    until queue.closed?
+      batch = queue.pop
+      push(batch) if batch
     end
+  end
+
+  private
+
+  def push(batch)
+    flux_writer.push(batch[:records], time: batch[:time])
+    logger.info "Successfully pushed #{batch[:records].size} record(s) " \
+                "from #{Time.at(batch[:time])} to InfluxDB"
+  rescue StandardError => e
+    error_handling(batch, e)
+
+    # Wait a bit before trying again
+    sleep(retry_delay)
+  end
+
+  def error_handling(batch, error)
+    logger.error "Error while pushing to InfluxDB: #{error.message}"
+
+    return if queue.closed?
+
+    # Put the batch back into the queue, to retry later
+    queue << batch
+
+    logger.info "The batch has been queued again. Will retry #{queue.size} batch(es) later."
   end
 end

--- a/lib/loop.rb
+++ b/lib/loop.rb
@@ -8,15 +8,56 @@ class Loop
 
   def_delegators :config, :logger
 
-  def initialize(config:, retry_wait: 5, max_count: nil)
+  def initialize(config:, retry_wait: 5, max_count: nil, max_wait: 12)
     @config = config
     @max_count = max_count
     @retry_wait = retry_wait
+    @max_wait = max_wait
   end
 
-  attr_reader :config, :max_count, :retry_wait
+  attr_reader :config, :max_count, :retry_wait, :max_wait
+  attr_accessor :queue
 
   def start
+    self.queue = Queue.new
+
+    return unless influx_ready?
+
+    receive_thread = Thread.new { receive_loop }
+    push_thread = Thread.new { push_loop }
+
+    # Wait for the receive thread to finish (will happen if max_count is set)
+    receive_thread.join
+
+    # Push any remaining records to InfluxDB
+    close_queue
+
+    # Wait for the push thread to finish (will happen because queue is closed)
+    push_thread.join
+  rescue SystemExit, Interrupt
+    logger.warn 'Exiting...'
+
+    # Stop receiving MQTT messages
+    receive_thread&.exit
+
+    # Push any remaining records to InfluxDB (can take a while)
+    close_queue
+
+    # Stop pushing data to InfluxDB
+    push_thread&.exit
+  end
+
+  def stop
+    mqtt_client&.disconnect
+  rescue MQTT::ProtocolException, StandardError => e
+    handle_exception(e)
+  end
+
+  private
+
+  # Receive MQTT messages and add the resulting records to the queue, for
+  # InfluxPush to write - reconnects to the broker on error.
+  def receive_loop
     subscribe_topics
     receive_messages
   rescue MQTT::ProtocolException, StandardError => e
@@ -27,14 +68,6 @@ class Loop
     # Maybe use this gem: https://github.com/kamui/retriable
 
     retry if max_count.nil?
-  rescue SystemExit, Interrupt
-    logger.warn 'Exiting...'
-  end
-
-  def stop
-    mqtt_client&.disconnect
-  rescue MQTT::ProtocolException, StandardError => e
-    handle_exception(e)
   end
 
   def subscribe_topics
@@ -47,7 +80,7 @@ class Loop
     count = 0
     loop do
       time, records = next_message
-      influx_push.call(records, time: time.to_i) if records.any?
+      queue << { records:, time: time.to_i } if records.any?
 
       count += 1
       break if max_count && count >= max_count
@@ -57,7 +90,9 @@ class Loop
   def next_message
     topic, message = mqtt_client.get
 
-    # There is no timestamp in the MQTT message, so we use the current time
+    # There is no timestamp in the MQTT message, so we use the current time.
+    # This travels with the records through the queue, so a write that's
+    # delayed by a retry still lands at the time the message actually arrived.
     time = Time.now
 
     # Log all the data we received
@@ -76,8 +111,42 @@ class Loop
     [time, records]
   end
 
+  # Wait until InfluxDB is reachable, for up to max_wait seconds
+  def influx_ready?
+    logger.info 'Wait until InfluxDB is ready ...'
+
+    count = 0
+    until (ready = influx_push.ready?) || (max_wait && count >= max_wait)
+      count += 1
+      sleep 1
+    end
+
+    if ready
+      logger.info 'InfluxDB is ready.'
+      true
+    else
+      logger.error "InfluxDB not ready after #{count} seconds - aborting."
+      false
+    end
+  end
+
+  # Push records from the queue to InfluxDB
+  def push_loop
+    influx_push.run
+  end
+
   def influx_push
-    @influx_push ||= InfluxPush.new(config:)
+    @influx_push ||= InfluxPush.new(config:, queue:)
+  end
+
+  # Wait for the queue to drain, then close it so the push thread can finish
+  def close_queue
+    until queue.empty?
+      logger.info "Waiting for #{queue.size} batch(es) to be pushed to InfluxDB"
+      sleep 1
+    end
+
+    queue.close
   end
 
   def mqtt_client

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -52,6 +52,7 @@ class Mapper
              "#{"#{mapping[:min]} ≥ " if mapping[:min]}#{mapping[:type]}" \
              "#{" ≤ #{mapping[:max]}" if mapping[:max]}" \
              "#{', converting NULL to 0' if mapping[:null_to_zero] == 'true'}" \
+             "#{", averaged every #{mapping[:aggregate_interval]}s" if mapping[:aggregate_interval]}" \
              ')'
   end
 
@@ -59,11 +60,7 @@ class Mapper
     value = value_from(message, mapping)
     remember_value(mapping, value)
 
-    if value && signed?(mapping)
-      map_with_sign(mapping, value)
-    else
-      map_default(mapping, value)
-    end
+    records_from(mapping, value)
   end
 
   # Recalculate all virtual mappings, since any of them might reference a
@@ -73,12 +70,57 @@ class Mapper
       value = virtual_value_from(mapping)
       remember_value(mapping, value)
 
-      if value && signed?(mapping)
-        map_with_sign(mapping, value)
-      else
-        map_default(mapping, value)
-      end
+      records_from(mapping, value)
     end
+  end
+
+  def records_from(mapping, value)
+    return [] if value.nil?
+
+    value = throttled(mapping, value)
+    return [] if value.nil?
+
+    if signed?(mapping)
+      map_with_sign(mapping, value)
+    else
+      map_default(mapping, value)
+    end
+  end
+
+  # If MAPPING_X_AGGREGATE_INTERVAL is set, don't pass every single value
+  # through - instead collect them and only return the average once the
+  # interval has passed, so high-frequency updates get throttled down to one
+  # write per interval. Returns the value unchanged if no interval is set.
+  def throttled(mapping, value)
+    interval = mapping[:aggregate_interval]&.to_f
+    return value unless interval
+
+    average = aggregate(mapping_key(mapping), value, interval)
+    return nil if average.nil?
+
+    convert_type(average, mapping)
+  end
+
+  # Collects values per mapping in a fixed window starting with the first
+  # value received for it. Returns nil while the window is still open, or the
+  # average of all values collected so far once the interval has elapsed -
+  # at which point the window resets, to start fresh with the next value.
+  def aggregate(key, value, interval)
+    now = monotonic_time
+    buffer = (aggregation_buffers[key] ||= { sum: 0.0, count: 0, window_start: now })
+
+    buffer[:sum] += value
+    buffer[:count] += 1
+
+    return nil if now - buffer[:window_start] < interval
+
+    average = buffer[:sum] / buffer[:count]
+    aggregation_buffers.delete(key)
+    average
+  end
+
+  def aggregation_buffers
+    @aggregation_buffers ||= {}
   end
 
   def virtual_value_from(mapping)

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -86,11 +86,36 @@ class Mapper
 
     if message.nil? && mapping[:null_to_zero] != 'true'
       config.logger.warn "  Formula for #{mapping[:field] || mapping[:field_positive]} " \
-                          'could not be evaluated (missing or outdated values), ignoring.'
+                          "could not be evaluated#{missing_references_note(mapping)}, ignoring."
       return
     end
 
     convert_type(message, mapping)
+  end
+
+  # Describes which of the mapping's referenced values are missing or expired,
+  # e.g. " (missing or outdated: MAPPING_0 [sensor/power])". Falls back to a
+  # generic note if the formula doesn't reference any (currently) unknown mapping.
+  def missing_references_note(mapping)
+    missing = missing_references(mapping)
+    return ' (missing or outdated values)' if missing.empty?
+
+    " (missing or outdated: #{missing.map { |key| describe_reference(key) }.join(', ')})"
+  end
+
+  def missing_references(mapping)
+    referenced_keys(mapping) - fresh_values.keys
+  end
+
+  def referenced_keys(mapping)
+    mapping[:formula].scan(/{(.*?)}/).flatten.uniq
+  end
+
+  def describe_reference(key)
+    mapping = mapping_by_key[key]
+    return key unless mapping
+
+    "#{key} [#{mapping[:topic] || mapping[:field] || mapping[:field_positive]}]"
   end
 
   # Remember the latest value of a mapping (keyed by "MAPPING_<group>"), along
@@ -114,8 +139,11 @@ class Mapper
   end
 
   def max_age_by_key
-    @max_age_by_key ||=
-      config.mappings.to_h { |mapping| [mapping_key(mapping), mapping[:max_age]&.to_f] }
+    @max_age_by_key ||= mapping_by_key.transform_values { |mapping| mapping[:max_age]&.to_f }
+  end
+
+  def mapping_by_key
+    @mapping_by_key ||= config.mappings.to_h { |mapping| [mapping_key(mapping), mapping] }
   end
 
   def mapping_key(mapping)

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -82,27 +82,52 @@ class Mapper
   end
 
   def virtual_value_from(mapping)
-    message = Evaluator.new(expression: mapping[:formula], data: last_values).run
+    message = Evaluator.new(expression: mapping[:formula], data: fresh_values).run
 
     if message.nil? && mapping[:null_to_zero] != 'true'
       config.logger.warn "  Formula for #{mapping[:field] || mapping[:field_positive]} " \
-                          'could not be evaluated (missing values), ignoring.'
+                          'could not be evaluated (missing or outdated values), ignoring.'
       return
     end
 
     convert_type(message, mapping)
   end
 
-  # Remember the latest value of a mapping (keyed by "MAPPING_<group>"), so
-  # virtual mappings can reference it via a placeholder like "{MAPPING_1}".
+  # Remember the latest value of a mapping (keyed by "MAPPING_<group>"), along
+  # with the time it was received, so virtual mappings can reference it via a
+  # placeholder like "{MAPPING_1}" - and so it can expire via MAX_AGE.
   def remember_value(mapping, value)
     return if value.nil?
 
-    last_values["MAPPING_#{mapping[:mapping_group]}"] = value
+    last_values[mapping_key(mapping)] = { value:, received_at: monotonic_time }
+  end
+
+  # Values for use in virtual mapping formulas, excluding any mapping whose
+  # last value is older than its own MAPPING_X_MAX_AGE (in seconds), if set.
+  def fresh_values
+    last_values.filter_map do |key, entry|
+      max_age = max_age_by_key[key]
+      next if max_age && (monotonic_time - entry[:received_at]) > max_age
+
+      [key, entry[:value]]
+    end.to_h
+  end
+
+  def max_age_by_key
+    @max_age_by_key ||=
+      config.mappings.to_h { |mapping| [mapping_key(mapping), mapping[:max_age]&.to_f] }
+  end
+
+  def mapping_key(mapping)
+    "MAPPING_#{mapping[:mapping_group]}"
   end
 
   def last_values
     @last_values ||= {}
+  end
+
+  def monotonic_time
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
   end
 
   def signed?(mapping)

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -53,6 +53,7 @@ class Mapper
              "#{" ≤ #{mapping[:max]}" if mapping[:max]}" \
              "#{', converting NULL to 0' if mapping[:null_to_zero] == 'true'}" \
              "#{", averaged every #{mapping[:aggregate_interval]}s" if mapping[:aggregate_interval]}" \
+             "#{', not written to InfluxDB' if mapping[:skip_write] == 'true'}" \
              ')'
   end
 
@@ -76,6 +77,7 @@ class Mapper
 
   def records_from(mapping, value)
     return [] if value.nil?
+    return [] if mapping[:skip_write] == 'true'
 
     value = throttled(mapping, value)
     return [] if value.nil?

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -94,13 +94,13 @@ class Mapper
   end
 
   # Describes which of the mapping's referenced values are missing or expired,
-  # e.g. " (missing or outdated: MAPPING_0 [sensor/power])". Falls back to a
+  # e.g. " (MAPPING_0 [sensor/power]: never received)". Falls back to a
   # generic note if the formula doesn't reference any (currently) unknown mapping.
   def missing_references_note(mapping)
     missing = missing_references(mapping)
     return ' (missing or outdated values)' if missing.empty?
 
-    " (missing or outdated: #{missing.map { |key| describe_reference(key) }.join(', ')})"
+    " (#{missing.map { |key| describe_reference(key) }.join(', ')})"
   end
 
   def missing_references(mapping)
@@ -113,9 +113,19 @@ class Mapper
 
   def describe_reference(key)
     mapping = mapping_by_key[key]
-    return key unless mapping
+    label = mapping ? "#{key} [#{mapping[:topic] || mapping[:field] || mapping[:field_positive]}]" : key
 
-    "#{key} [#{mapping[:topic] || mapping[:field] || mapping[:field_positive]}]"
+    "#{label}: #{reference_status(key)}"
+  end
+
+  # Distinguishes a value that was never received at all from one that was
+  # received but is now older than its own MAPPING_X_MAX_AGE.
+  def reference_status(key)
+    entry = last_values[key]
+    return 'never received' unless entry
+
+    age = (monotonic_time - entry[:received_at]).round
+    "last received #{age}s ago, exceeds MAX_AGE of #{max_age_by_key[key].to_i}s"
   end
 
   # Remember the latest value of a mapping (keyed by "MAPPING_<group>"), along

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -1,5 +1,7 @@
 require 'evaluator'
 
+DEFAULT_HEARTBEAT_INTERVAL = 60
+
 class Mapper
   def initialize(config:)
     @config = config
@@ -46,7 +48,14 @@ class Mapper
              "#{', converting NULL to 0' if mapping[:null_to_zero] == 'true'}" \
              "#{", averaged every #{mapping[:aggregate_interval]}s" if mapping[:aggregate_interval]}" \
              "#{', not written to InfluxDB' if mapping[:skip_write] == 'true'}" \
+             "#{dedup_description(mapping)}" \
              ')'
+  end
+
+  def dedup_description(mapping)
+    return '' unless mapping[:dedup] == 'true'
+
+    ", deduplicated (heartbeat #{mapping[:heartbeat_interval] || DEFAULT_HEARTBEAT_INTERVAL}s)"
   end
 
   def mapping_target(mapping)
@@ -85,11 +94,58 @@ class Mapper
     value = throttled(mapping, value)
     return [] if value.nil?
 
-    if signed?(mapping)
-      map_with_sign(mapping, value)
-    else
-      map_default(mapping, value)
+    records =
+      if signed?(mapping)
+        map_with_sign(mapping, value)
+      else
+        map_default(mapping, value)
+      end
+
+    deduped(mapping, records)
+  end
+
+  # If MAPPING_X_DEDUP is set, a record is only passed through when its value
+  # actually changed - except a zero value is always written once and then
+  # suppressed for as long as it stays zero (no further signal needed), while
+  # a repeated non-zero value is still written every MAPPING_X_HEARTBEAT_INTERVAL
+  # seconds (default 60), to show that the sender is still alive.
+  def deduped(mapping, records)
+    return records unless mapping[:dedup] == 'true'
+
+    interval = (mapping[:heartbeat_interval] || DEFAULT_HEARTBEAT_INTERVAL).to_f
+    records.select { |record| due_for_write?(record, interval) }
+  end
+
+  def due_for_write?(record, interval)
+    key = [record[:measurement], record[:field]]
+    last = dedup_state[key]
+
+    if last.nil? || last[:value] != record[:value]
+      dedup_state[key] = { value: record[:value], written_at: monotonic_time }
+      return true
     end
+
+    return false if zero_ish?(record[:value])
+
+    return false if monotonic_time - last[:written_at] < interval
+
+    last[:written_at] = monotonic_time
+    true
+  end
+
+  def zero_ish?(value)
+    case value
+    when Numeric
+      value.zero?
+    when true, false
+      value == false
+    else
+      false
+    end
+  end
+
+  def dedup_state
+    @dedup_state ||= {}
   end
 
   # If MAPPING_X_AGGREGATE_INTERVAL is set, don't pass every single value

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -8,28 +8,20 @@ class Mapper
   attr_reader :config
 
   def topics
-    @topics ||= config.mappings.map { |mapping| mapping[:topic] }.sort.uniq
+    @topics ||=
+      config.mappings.filter_map { |mapping| mapping[:topic] }.sort.uniq
   end
 
   def formatted_mapping(topic)
-    mappings_for(topic)
-      .map do |mapping|
-        result =
-          if signed?(mapping)
-            "#{mapping[:measurement_positive]}:#{mapping[:field_positive]} (+) " \
-              "#{mapping[:measurement_negative]}:#{mapping[:field_negative]} (-)"
-          else
-            "#{mapping[:measurement]}:#{mapping[:field]}"
-          end
+    mappings_for(topic).map { |mapping| describe_mapping(mapping) }.join(', ')
+  end
 
-        result += ' (' \
-                  "#{"#{mapping[:min]} ≥ " if mapping[:min]}#{mapping[:type]}" \
-                  "#{" ≤ #{mapping[:max]}" if mapping[:max]}" \
-                  "#{', converting NULL to 0' if mapping[:null_to_zero] == 'true'}" \
-                  ')'
-        result
-      end
-      .join(', ')
+  def formatted_virtual_mapping(mapping)
+    "#{describe_mapping(mapping)} = #{mapping[:formula]}"
+  end
+
+  def virtual_mappings
+    config.mappings.select { |mapping| mapping[:topic].nil? }
   end
 
   def records_for(topic, message)
@@ -38,20 +30,80 @@ class Mapper
     mappings = mappings_for(topic)
     raise "Unknown mapping for topic: #{topic}" if mappings.empty?
 
-    mappings
-      .map do |mapping|
-        value = value_from(message, mapping)
-        if value && signed?(mapping)
-          map_with_sign(mapping, value)
-        else
-          map_default(mapping, value)
-        end
-      end
+    records = mappings.map { |mapping| records_for_mapping(mapping, message) }
+
+    (records + virtual_records)
       .flatten
       .delete_if { |record| record[:value].nil? }
   end
 
   private
+
+  def describe_mapping(mapping)
+    result =
+      if signed?(mapping)
+        "#{mapping[:measurement_positive]}:#{mapping[:field_positive]} (+) " \
+          "#{mapping[:measurement_negative]}:#{mapping[:field_negative]} (-)"
+      else
+        "#{mapping[:measurement]}:#{mapping[:field]}"
+      end
+
+    result + ' (' \
+             "#{"#{mapping[:min]} ≥ " if mapping[:min]}#{mapping[:type]}" \
+             "#{" ≤ #{mapping[:max]}" if mapping[:max]}" \
+             "#{', converting NULL to 0' if mapping[:null_to_zero] == 'true'}" \
+             ')'
+  end
+
+  def records_for_mapping(mapping, message)
+    value = value_from(message, mapping)
+    remember_value(mapping, value)
+
+    if value && signed?(mapping)
+      map_with_sign(mapping, value)
+    else
+      map_default(mapping, value)
+    end
+  end
+
+  # Recalculate all virtual mappings, since any of them might reference a
+  # value that just changed.
+  def virtual_records
+    virtual_mappings.map do |mapping|
+      value = virtual_value_from(mapping)
+      remember_value(mapping, value)
+
+      if value && signed?(mapping)
+        map_with_sign(mapping, value)
+      else
+        map_default(mapping, value)
+      end
+    end
+  end
+
+  def virtual_value_from(mapping)
+    message = Evaluator.new(expression: mapping[:formula], data: last_values).run
+
+    if message.nil? && mapping[:null_to_zero] != 'true'
+      config.logger.warn "  Formula for #{mapping[:field] || mapping[:field_positive]} " \
+                          'could not be evaluated (missing values), ignoring.'
+      return
+    end
+
+    convert_type(message, mapping)
+  end
+
+  # Remember the latest value of a mapping (keyed by "MAPPING_<group>"), so
+  # virtual mappings can reference it via a placeholder like "{MAPPING_1}".
+  def remember_value(mapping, value)
+    return if value.nil?
+
+    last_values["MAPPING_#{mapping[:mapping_group]}"] = value
+  end
+
+  def last_values
+    @last_values ||= {}
+  end
 
   def signed?(mapping)
     (

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -40,21 +40,24 @@ class Mapper
   private
 
   def describe_mapping(mapping)
-    result =
-      if signed?(mapping)
-        "#{mapping[:measurement_positive]}:#{mapping[:field_positive]} (+) " \
-          "#{mapping[:measurement_negative]}:#{mapping[:field_negative]} (-)"
-      else
-        "#{mapping[:measurement]}:#{mapping[:field]}"
-      end
-
-    result + ' (' \
+    mapping_target(mapping) + ' (' \
              "#{"#{mapping[:min]} ≥ " if mapping[:min]}#{mapping[:type]}" \
              "#{" ≤ #{mapping[:max]}" if mapping[:max]}" \
              "#{', converting NULL to 0' if mapping[:null_to_zero] == 'true'}" \
              "#{", averaged every #{mapping[:aggregate_interval]}s" if mapping[:aggregate_interval]}" \
              "#{', not written to InfluxDB' if mapping[:skip_write] == 'true'}" \
              ')'
+  end
+
+  def mapping_target(mapping)
+    if signed?(mapping)
+      "#{mapping[:measurement_positive]}:#{mapping[:field_positive]} (+) " \
+        "#{mapping[:measurement_negative]}:#{mapping[:field_negative]} (-)"
+    elsif mapping[:measurement] || mapping[:field]
+      "#{mapping[:measurement]}:#{mapping[:field]}"
+    else
+      '(no InfluxDB field)'
+    end
   end
 
   def records_for_mapping(mapping, message)

--- a/spec/cassettes/influx_success.yml
+++ b/spec/cassettes/influx_success.yml
@@ -32,4 +32,34 @@ http_interactions:
       encoding: UTF-8
       string: ''
   recorded_at: Fri, 20 Sep 2024 06:04:21 GMT
+- request:
+    method: get
+    uri: http://localhost:8086/ping
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - influxdb-client-ruby/3.2.0
+      Authorization:
+      - Token my-token
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Influxdb-Build:
+      - OSS
+      X-Influxdb-Version:
+      - v2.8.0
+      Date:
+      - Fri, 27 Feb 2026 04:49:01 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Fri, 27 Feb 2026 04:49:01 GMT
 recorded_with: VCR 6.3.1

--- a/spec/lib/config_mapping_spec.rb
+++ b/spec/lib/config_mapping_spec.rb
@@ -145,4 +145,29 @@ describe Config, '#mapping' do
       )
     end
   end
+
+  context 'with a SKIP_WRITE mapping that omits FIELD and MEASUREMENT' do
+    let(:env) do
+      other_env.merge(
+        {
+          'MAPPING_0_TOPIC' => 'senec/0/ENERGY/GUI_INVERTER_POWER',
+          'MAPPING_0_TYPE' => 'integer',
+          'MAPPING_0_SKIP_WRITE' => 'true',
+        },
+      )
+    end
+
+    it 'does not raise, since the value is never written to InfluxDB' do
+      expect(mappings).to eq(
+        [
+          {
+            topic: 'senec/0/ENERGY/GUI_INVERTER_POWER',
+            type: 'integer',
+            skip_write: 'true',
+            mapping_group: '0',
+          },
+        ],
+      )
+    end
+  end
 end

--- a/spec/lib/config_mapping_spec.rb
+++ b/spec/lib/config_mapping_spec.rb
@@ -85,12 +85,64 @@ describe Config, '#mapping' do
         MAPPING_0_MEASUREMENT: 'measurement',
         MAPPING_1_FIELD: 'field',
       },
+      # Virtual mapping (no topic) is missing the formula
+      {
+        MAPPING_0_MEASUREMENT: 'measurement',
+        MAPPING_0_FIELD: 'field',
+        MAPPING_0_TYPE: 'float',
+      },
+      # Virtual mapping (no topic) cannot use JSON_KEY
+      {
+        MAPPING_0_MEASUREMENT: 'measurement',
+        MAPPING_0_FIELD: 'field',
+        MAPPING_0_TYPE: 'float',
+        MAPPING_0_FORMULA: '{MAPPING_1}',
+        MAPPING_0_JSON_KEY: 'key',
+      },
     ].each do |hash|
       let(:env) { other_env.merge(hash) }
 
       it 'raises an error' do
         expect { config }.to raise_error(Config::Error)
       end
+    end
+  end
+
+  context 'with valid virtual mapping env (no topic, calculated from other mappings)' do
+    let(:env) do
+      other_env.merge(
+        {
+          'MAPPING_0_TOPIC' => 'senec/0/ENERGY/GUI_INVERTER_POWER',
+          'MAPPING_0_MEASUREMENT' => 'PV',
+          'MAPPING_0_FIELD' => 'inverter_power',
+          'MAPPING_0_TYPE' => 'integer',
+          'MAPPING_1_MEASUREMENT' => 'PV',
+          'MAPPING_1_FIELD' => 'inverter_power_doubled',
+          'MAPPING_1_TYPE' => 'integer',
+          'MAPPING_1_FORMULA' => '{MAPPING_0} * 2',
+        },
+      )
+    end
+
+    it 'returns mappings as array, including the virtual one without a topic' do
+      expect(mappings).to eq(
+        [
+          {
+            topic: 'senec/0/ENERGY/GUI_INVERTER_POWER',
+            measurement: 'PV',
+            field: 'inverter_power',
+            type: 'integer',
+            mapping_group: '0',
+          },
+          {
+            measurement: 'PV',
+            field: 'inverter_power_doubled',
+            type: 'integer',
+            formula: '{MAPPING_0} * 2',
+            mapping_group: '1',
+          },
+        ],
+      )
     end
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -518,6 +518,9 @@ describe Config do
       # Invalid skip_write
       [:merge, { 'MAPPING_0_SKIP_WRITE' => 'this-is-no-boolean' },
        'Variable MAPPING_0_SKIP_WRITE is invalid: this-is-no-boolean. Must be one of: true, false',],
+      # Invalid dedup
+      [:merge, { 'MAPPING_0_DEDUP' => 'this-is-no-boolean' },
+       'Variable MAPPING_0_DEDUP is invalid: this-is-no-boolean. Must be one of: true, false',],
     ].each do |method_name, argument, error_message|
       it "raises a Config::Error ('#{error_message}')" do
         env = valid_env.public_send(method_name, argument)

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -515,6 +515,9 @@ describe Config do
       # Invalid null_to_zero
       [:merge, { 'MAPPING_0_NULL_TO_ZERO' => 'this-is-no-boolean' },
        'Variable MAPPING_0_NULL_TO_ZERO is invalid: this-is-no-boolean. Must be one of: true, false',],
+      # Invalid skip_write
+      [:merge, { 'MAPPING_0_SKIP_WRITE' => 'this-is-no-boolean' },
+       'Variable MAPPING_0_SKIP_WRITE is invalid: this-is-no-boolean. Must be one of: true, false',],
     ].each do |method_name, argument, error_message|
       it "raises a Config::Error ('#{error_message}')" do
         env = valid_env.public_send(method_name, argument)

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -483,7 +483,8 @@ describe Config do
   describe 'invalid mappings' do
     [
       # Missing keys (for a simple mapping)
-      [:except, 'MAPPING_0_TOPIC', 'Missing variable: MAPPING_0_TOPIC'],
+      # Without a topic, the mapping is considered virtual and requires a formula instead
+      [:except, 'MAPPING_0_TOPIC', 'Missing variable: MAPPING_0_FORMULA'],
       [:except, 'MAPPING_0_FIELD', 'Missing variable: MAPPING_0_FIELD'],
       [:except, 'MAPPING_0_MEASUREMENT', 'Missing variable: MAPPING_0_MEASUREMENT'],
       [:except, 'MAPPING_0_TYPE', 'Missing variable: MAPPING_0_TYPE'],
@@ -493,7 +494,8 @@ describe Config do
       [:except, 'MAPPING_4_MEASUREMENT_POSITIVE', 'Missing variable: MAPPING_4_MEASUREMENT_POSITIVE'],
       [:except, 'MAPPING_4_MEASUREMENT_NEGATIVE', 'Missing variable: MAPPING_4_MEASUREMENT_NEGATIVE'],
       # Blank keys (for a simple mapping)
-      [:merge, { 'MAPPING_0_TOPIC' => '' }, 'Missing variable: MAPPING_0_TOPIC'],
+      # A blank topic is treated the same as a missing one (virtual mapping)
+      [:merge, { 'MAPPING_0_TOPIC' => '' }, 'Missing variable: MAPPING_0_FORMULA'],
       [:merge, { 'MAPPING_0_FIELD' => '' }, 'Missing variable: MAPPING_0_FIELD'],
       [:merge, { 'MAPPING_0_MEASUREMENT' => '' }, 'Missing variable: MAPPING_0_MEASUREMENT'],
       [:merge, { 'MAPPING_0_TYPE' => '' }, 'Missing variable: MAPPING_0_TYPE'],

--- a/spec/lib/evaluator_spec.rb
+++ b/spec/lib/evaluator_spec.rb
@@ -149,4 +149,22 @@ describe Evaluator do
       expect(evaluator.run).to be_nil
     end
   end
+
+  context 'with missing data and a comparison operator' do
+    let(:data) { { 'a' => 2 } }
+
+    it 'returns nil for !=, instead of treating the missing value as a real nil' do
+      expect(described_class.new(expression: '{a} != {b}', data:).run).to be_nil
+    end
+
+    it 'returns nil for ==, instead of treating the missing value as a real nil' do
+      expect(described_class.new(expression: '{a} == {b}', data:).run).to be_nil
+    end
+
+    it 'returns nil for IF() using a comparison with the missing value' do
+      expect(
+        described_class.new(expression: "IF({a} != {b}, {a}, 'unreachable')", data:).run,
+      ).to be_nil
+    end
+  end
 end

--- a/spec/lib/flux_writer_spec.rb
+++ b/spec/lib/flux_writer_spec.rb
@@ -1,0 +1,28 @@
+require 'flux_writer'
+require 'config'
+
+describe FluxWriter do
+  subject(:flux_writer) { described_class.new(config) }
+
+  let(:config) { Config.new(ENV, logger: MemoryLogger.new) }
+
+  describe '#ready?' do
+    it 'returns true when InfluxDB responds to ping', vcr: 'influx_success' do
+      expect(flux_writer.ready?).to be true
+    end
+
+    it 'returns false when InfluxDB is unreachable' do
+      stub_request(:get, 'http://localhost:8086/ping').to_raise(Errno::ECONNREFUSED)
+
+      expect(flux_writer.ready?).to be false
+    end
+  end
+
+  describe '#push' do
+    it 'writes the records to InfluxDB', vcr: 'influx_success' do
+      records = [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }]
+
+      expect { flux_writer.push(records, time: 1_726_812_261) }.not_to raise_error
+    end
+  end
+end

--- a/spec/lib/influx_push_spec.rb
+++ b/spec/lib/influx_push_spec.rb
@@ -1,37 +1,98 @@
+require 'timeout'
 require 'influx_push'
 require 'config'
 
 describe InfluxPush do
-  subject(:influx_push) { described_class.new(config:) }
+  subject(:influx_push) { described_class.new(config:, queue:, retry_delay: 0.1) }
 
-  let(:config) { Config.new(ENV, logger: MemoryLogger.new) }
+  let(:config) { Config.new(ENV, logger:) }
+  let(:logger) { MemoryLogger.new }
+  let(:queue) { Queue.new }
 
-  it 'initializes with a config' do
-    expect(influx_push.config).to eq(config)
+  describe '#ready?' do
+    it 'delegates to FluxWriter#ready?', vcr: 'influx_success' do
+      expect(influx_push.ready?).to be true
+    end
   end
 
-  it 'can push records to InfluxDB', vcr: 'influx_success' do
-    time = Time.now
-    records = [{ fields: { key: 'value' } }]
+  describe '#run' do
+    it 'pushes a single queued batch to InfluxDB', vcr: 'influx_success' do
+      queue << { records: [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }], time: 1_726_812_261 }
 
-    influx_push.call(records, time:)
+      run_until_drained
+
+      expect(logger.info_messages).to include(/Successfully pushed 1 record\(s\) from .* to InfluxDB/)
+      expect(logger.error_messages).to be_empty
+    end
+
+    it 'pushes multiple queued batches to InfluxDB', vcr: 'influx_success' do
+      2.times do
+        queue << { records: [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }], time: 1_726_812_261 }
+      end
+
+      run_until_drained
+
+      expect(logger.info_messages.grep(/Successfully pushed/).size).to eq(2)
+    end
+
+    it 'keeps retrying a batch that keeps failing, instead of dropping it' do
+      allow(FluxWriter).to receive(:new).and_return(always_failing_flux_writer)
+
+      batch = { records: [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }], time: 1_726_812_261 }
+      queue << batch
+
+      thread = Thread.new { influx_push.run }
+
+      expect { Timeout.timeout(0.5) { loop until queue.empty? } }.to raise_error(Timeout::Error)
+
+      expect(logger.error_messages).to include(/Error while pushing to InfluxDB: temporarily unreachable/)
+      expect(logger.info_messages).to include(/The batch has been queued again/)
+      expect(queue.size).to eq(1)
+
+      queue.close
+      thread.exit
+    end
+
+    it 'delivers a batch with its original timestamp once InfluxDB recovers' do
+      pushed = Queue.new
+      attempts = 0
+
+      allow(FluxWriter).to receive(:new).and_return(
+        instance_double(FluxWriter).tap do |writer|
+          allow(writer).to receive(:push) do |records, time:|
+            attempts += 1
+            raise 'temporarily unreachable' if attempts == 1
+
+            pushed << { records:, time: }
+          end
+        end,
+      )
+
+      original_time = 1_700_000_000
+      queue << { records: [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }], time: original_time }
+
+      thread = Thread.new { influx_push.run }
+
+      delivered = Timeout.timeout(2) { pushed.pop }
+      queue.close
+      thread.join
+
+      expect(delivered[:time]).to eq(original_time)
+      expect(logger.error_messages).to include(/Error while pushing to InfluxDB: temporarily unreachable/)
+      expect(logger.info_messages).to include(/Successfully pushed 1 record\(s\)/)
+    end
   end
 
-  it 'can handle error' do
-    fake_flux = instance_double(FluxWriter)
-    allow(fake_flux).to receive(:push).and_raise(StandardError)
-    allow(FluxWriter).to receive(:new).and_return(fake_flux)
+  def run_until_drained
+    thread = Thread.new { influx_push.run }
+    Timeout.timeout(2) { sleep 0.01 until queue.empty? }
+    queue.close
+    thread.join
+  end
 
-    time = Time.now
-    records = [{ fields: { key: 'value' } }]
-
-    expect do
-      influx_push.call(records, time:, retries: 1, retry_delay: 0.1)
-    end.to raise_error(StandardError)
-
-    expect(config.logger.error_messages).to include(
-      'Error while pushing to InfluxDB: StandardError',
-    )
-    sleep(1)
+  def always_failing_flux_writer
+    instance_double(FluxWriter).tap do |writer|
+      allow(writer).to receive(:push).and_raise('temporarily unreachable')
+    end
   end
 end

--- a/spec/lib/loop_spec.rb
+++ b/spec/lib/loop_spec.rb
@@ -2,7 +2,7 @@ require 'loop'
 require 'config'
 
 describe Loop do
-  subject(:loop) { described_class.new(config:, max_count: 1, retry_wait: 1) }
+  let(:loop) { described_class.new(config:, max_count: 1, retry_wait: 1) }
 
   let(:config) do
     Config.new(
@@ -37,6 +37,8 @@ describe Loop do
     end
 
     context 'when the MQTT server is not running' do
+      before { allow(loop).to receive(:influx_ready?).and_return(true) }
+
       it 'handles errors' do
         loop.start
 
@@ -49,12 +51,69 @@ describe Loop do
     end
 
     context 'when interrupted' do
-      before { allow(MQTT::Client).to receive(:new).and_raise(Interrupt) }
+      before do
+        allow(loop).to receive(:influx_ready?).and_return(true)
+        allow(MQTT::Client).to receive(:new).and_raise(Interrupt)
+      end
 
       it 'handles interruption' do
         loop.start
 
         expect(logger.warn_messages).to include(/Exiting/)
+      end
+    end
+
+    context 'when InfluxDB is not ready' do
+      let(:loop) { described_class.new(config:, max_count: 1, max_wait: 0) }
+      let(:config) { Config.new(ENV.to_h, logger:) }
+
+      it 'aborts without ever subscribing to MQTT' do
+        stub_request(:get, 'http://localhost:8086/ping').to_raise(Errno::ECONNREFUSED)
+        allow(MQTT::Client).to receive(:connect)
+
+        loop.start
+
+        expect(MQTT::Client).not_to have_received(:connect)
+        expect(logger.error_messages).to include(/InfluxDB not ready after 0 seconds - aborting/)
+      end
+    end
+
+    context 'when InfluxDB becomes ready only after retrying' do
+      before do
+        allow(loop).to receive(:sleep)
+        allow(loop).to receive(:receive_loop)
+        allow(loop).to receive(:push_loop)
+
+        fake_influx_push = instance_double(InfluxPush)
+        allow(fake_influx_push).to receive(:ready?).and_return(false, true)
+        allow(loop).to receive(:influx_push).and_return(fake_influx_push)
+      end
+
+      it 'waits and retries the readiness check before continuing' do
+        loop.start
+
+        expect(logger.info_messages).to include(/Wait until InfluxDB is ready/)
+        expect(logger.info_messages).to include(/InfluxDB is ready/)
+      end
+    end
+
+    context 'when the queue takes a moment to drain' do
+      before do
+        allow(loop).to receive(:sleep)
+        allow(loop).to receive(:influx_ready?).and_return(true)
+        allow(loop).to receive(:receive_loop)
+        allow(loop).to receive(:push_loop)
+
+        fake_queue = Queue.new
+        fake_queue << { records: [], time: 0 }
+        allow(fake_queue).to receive(:empty?).and_return(false, true)
+        allow(Queue).to receive(:new).and_return(fake_queue)
+      end
+
+      it 'logs progress while waiting for the queue to drain' do
+        loop.start
+
+        expect(logger.info_messages).to include(/Waiting for 1 batch\(es\) to be pushed to InfluxDB/)
       end
     end
   end

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -345,6 +345,11 @@ SKIP_WRITE_ENV = {
   'MAPPING_2_FIELD' => 'total_power',
   'MAPPING_2_TYPE' => 'integer',
   'MAPPING_2_FORMULA' => '{MAPPING_0} + {MAPPING_1}',
+  #
+  # Skipped mapping without FIELD/MEASUREMENT at all - only feeds MAPPING_2
+  'MAPPING_3_TOPIC' => 'sensor/heatpump',
+  'MAPPING_3_TYPE' => 'integer',
+  'MAPPING_3_SKIP_WRITE' => 'true',
 }.freeze
 
 describe Mapper do
@@ -955,6 +960,15 @@ describe Mapper do
         'Washer:power (integer, not written to InfluxDB)',
       )
       expect(mapper.formatted_mapping('sensor/dryer')).to eq('Dryer:power (integer)')
+    end
+
+    it 'does not require FIELD/MEASUREMENT for a skipped mapping' do
+      hash = mapper.records_for('sensor/heatpump', '42')
+
+      expect(hash).to eq([])
+      expect(mapper.formatted_mapping('sensor/heatpump')).to eq(
+        '(no InfluxDB field) (integer, not written to InfluxDB)',
+      )
     end
   end
 end

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -318,6 +318,35 @@ AGGREGATE_ENV = {
   'MAPPING_2_AGGREGATE_INTERVAL' => '5',
 }.freeze
 
+SKIP_WRITE_ENV = {
+  'MQTT_HOST' => '1.2.3.4',
+  'MQTT_PORT' => '1883',
+  # ---
+  'INFLUX_HOST' => 'influx.example.com',
+  'INFLUX_SCHEMA' => 'https',
+  'INFLUX_PORT' => '443',
+  'INFLUX_TOKEN' => 'this.is.just.an.example',
+  'INFLUX_ORG' => 'solectrus',
+  'INFLUX_BUCKET' => 'my-bucket',
+  # ---
+  'MAPPING_0_TOPIC' => 'sensor/washer',
+  'MAPPING_0_MEASUREMENT' => 'Washer',
+  'MAPPING_0_FIELD' => 'power',
+  'MAPPING_0_TYPE' => 'integer',
+  'MAPPING_0_SKIP_WRITE' => 'true',
+  #
+  'MAPPING_1_TOPIC' => 'sensor/dryer',
+  'MAPPING_1_MEASUREMENT' => 'Dryer',
+  'MAPPING_1_FIELD' => 'power',
+  'MAPPING_1_TYPE' => 'integer',
+  #
+  # Virtual mapping: no topic, calculated from MAPPING_0 (skipped) and MAPPING_1 (written)
+  'MAPPING_2_MEASUREMENT' => 'Household',
+  'MAPPING_2_FIELD' => 'total_power',
+  'MAPPING_2_TYPE' => 'integer',
+  'MAPPING_2_FORMULA' => '{MAPPING_0} + {MAPPING_1}',
+}.freeze
+
 describe Mapper do
   subject(:mapper) { described_class.new(config:) }
 
@@ -888,6 +917,44 @@ describe Mapper do
           { field: 'signed_plus', measurement: 'PV', value: 10 },
         ],
       )
+    end
+  end
+
+  context 'with MAPPING_X_SKIP_WRITE' do
+    subject(:mapper) { described_class.new(config:) }
+
+    let(:config) { Config.new(SKIP_WRITE_ENV, logger:) }
+    let(:logger) { MemoryLogger.new }
+
+    it 'does not write the skipped mapping, but still writes a regular one' do
+      hash = mapper.records_for('sensor/dryer', '500')
+
+      expect(hash).to eq([{ field: 'power', measurement: 'Dryer', value: 500 }])
+    end
+
+    it 'never writes the skipped mapping, even alone on its own topic' do
+      hash = mapper.records_for('sensor/washer', '300')
+
+      expect(hash).to eq([])
+    end
+
+    it 'still uses the skipped mapping value in a virtual mapping formula' do
+      mapper.records_for('sensor/washer', '300')
+      hash = mapper.records_for('sensor/dryer', '500')
+
+      expect(hash).to eq(
+        [
+          { field: 'power', measurement: 'Dryer', value: 500 },
+          { field: 'total_power', measurement: 'Household', value: 800 },
+        ],
+      )
+    end
+
+    it 'mentions skipped mappings in the formatted description' do
+      expect(mapper.formatted_mapping('sensor/washer')).to eq(
+        'Washer:power (integer, not written to InfluxDB)',
+      )
+      expect(mapper.formatted_mapping('sensor/dryer')).to eq('Dryer:power (integer)')
     end
   end
 end

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -251,6 +251,12 @@ MAX_AGE_ENV = {
   'MAPPING_2_FIELD' => 'shadow_power',
   'MAPPING_2_TYPE' => 'integer',
   'MAPPING_2_FORMULA' => '{MAPPING_0} + {MAPPING_1}',
+  #
+  # Unrelated topic, only used to trigger a virtual mapping recalculation
+  'MAPPING_3_TOPIC' => 'sensor/decoy',
+  'MAPPING_3_MEASUREMENT' => 'PV',
+  'MAPPING_3_FIELD' => 'decoy',
+  'MAPPING_3_TYPE' => 'integer',
 }.freeze
 
 describe Mapper do
@@ -695,7 +701,21 @@ describe Mapper do
       expect(hash).to eq(
         [{ field: 'other', measurement: 'PV', value: 5 }],
       )
-      expect(logger.warn_messages).to include(/Formula for shadow_power.*outdated/)
+      expect(logger.warn_messages).to include(
+        %r{Formula for shadow_power could not be evaluated \(missing or outdated: MAPPING_0 \[sensor/power\]\)},
+      )
+    end
+
+    it 'names all missing or outdated references, not just the first one' do
+      # Neither MAPPING_0 nor MAPPING_1 has ever received a value
+      hash = mapper.records_for('sensor/decoy', '1')
+
+      expect(hash).to eq(
+        [{ field: 'decoy', measurement: 'PV', value: 1 }],
+      )
+      expect(logger.warn_messages).to include(
+        %r{Formula for shadow_power.*MAPPING_0 \[sensor/power\].*MAPPING_1 \[sensor/other\]},
+      )
     end
   end
 end

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -224,6 +224,35 @@ VIRTUAL_ENV = {
   'MAPPING_4_FORMULA' => '{MAPPING_0} - {MAPPING_1}',
 }.freeze
 
+MAX_AGE_ENV = {
+  'MQTT_HOST' => '1.2.3.4',
+  'MQTT_PORT' => '1883',
+  # ---
+  'INFLUX_HOST' => 'influx.example.com',
+  'INFLUX_SCHEMA' => 'https',
+  'INFLUX_PORT' => '443',
+  'INFLUX_TOKEN' => 'this.is.just.an.example',
+  'INFLUX_ORG' => 'solectrus',
+  'INFLUX_BUCKET' => 'my-bucket',
+  # ---
+  'MAPPING_0_TOPIC' => 'sensor/power',
+  'MAPPING_0_MEASUREMENT' => 'PV',
+  'MAPPING_0_FIELD' => 'power',
+  'MAPPING_0_TYPE' => 'integer',
+  'MAPPING_0_MAX_AGE' => '30',
+  #
+  'MAPPING_1_TOPIC' => 'sensor/other',
+  'MAPPING_1_MEASUREMENT' => 'PV',
+  'MAPPING_1_FIELD' => 'other',
+  'MAPPING_1_TYPE' => 'integer',
+  #
+  # Virtual mapping: no topic, calculated from MAPPING_0 and MAPPING_1
+  'MAPPING_2_MEASUREMENT' => 'PV',
+  'MAPPING_2_FIELD' => 'shadow_power',
+  'MAPPING_2_TYPE' => 'integer',
+  'MAPPING_2_FORMULA' => '{MAPPING_0} + {MAPPING_1}',
+}.freeze
+
 describe Mapper do
   subject(:mapper) { described_class.new(config:) }
 
@@ -630,6 +659,43 @@ describe Mapper do
           { field: 'net_power_plus', measurement: 'PV', value: 1400 },
         ],
       )
+    end
+  end
+
+  context 'with MAPPING_X_MAX_AGE' do
+    subject(:mapper) { described_class.new(config:) }
+
+    let(:config) { Config.new(MAX_AGE_ENV, logger:) }
+    let(:logger) { MemoryLogger.new }
+
+    it 'still uses a value within MAX_AGE' do
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(1000.0)
+      mapper.records_for('sensor/power', '100')
+
+      # 10 seconds later - still within MAX_AGE of 30 seconds
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(1010.0)
+      hash = mapper.records_for('sensor/other', '5')
+
+      expect(hash).to eq(
+        [
+          { field: 'other', measurement: 'PV', value: 5 },
+          { field: 'shadow_power', measurement: 'PV', value: 105 },
+        ],
+      )
+    end
+
+    it 'ignores a value beyond MAX_AGE, as if it was never received' do
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(1000.0)
+      mapper.records_for('sensor/power', '100')
+
+      # 31 seconds later - beyond MAX_AGE of 30 seconds
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(1031.0)
+      hash = mapper.records_for('sensor/other', '5')
+
+      expect(hash).to eq(
+        [{ field: 'other', measurement: 'PV', value: 5 }],
+      )
+      expect(logger.warn_messages).to include(/Formula for shadow_power.*outdated/)
     end
   end
 end

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -181,6 +181,49 @@ EXPECTED_TOPICS = %w[
   somewhere/power-negative
 ].freeze
 
+VIRTUAL_ENV = {
+  'MQTT_HOST' => '1.2.3.4',
+  'MQTT_PORT' => '1883',
+  # ---
+  'INFLUX_HOST' => 'influx.example.com',
+  'INFLUX_SCHEMA' => 'https',
+  'INFLUX_PORT' => '443',
+  'INFLUX_TOKEN' => 'this.is.just.an.example',
+  'INFLUX_ORG' => 'solectrus',
+  'INFLUX_BUCKET' => 'my-bucket',
+  # ---
+  'MAPPING_0_TOPIC' => 'senec/0/ENERGY/GUI_INVERTER_POWER',
+  'MAPPING_0_MEASUREMENT' => 'PV',
+  'MAPPING_0_FIELD' => 'inverter_power',
+  'MAPPING_0_TYPE' => 'integer',
+  #
+  'MAPPING_1_TOPIC' => 'senec/0/ENERGY/GUI_HOUSE_POW',
+  'MAPPING_1_MEASUREMENT' => 'PV',
+  'MAPPING_1_FIELD' => 'house_power',
+  'MAPPING_1_TYPE' => 'integer',
+  #
+  # Virtual mapping: no topic, calculated from MAPPING_0 and MAPPING_1
+  'MAPPING_2_MEASUREMENT' => 'PV',
+  'MAPPING_2_FIELD' => 'total_power',
+  'MAPPING_2_TYPE' => 'integer',
+  'MAPPING_2_FORMULA' => '{MAPPING_0} + {MAPPING_1}',
+  #
+  # Virtual mapping: no topic, referencing a mapping that never receives data
+  'MAPPING_3_MEASUREMENT' => 'PV',
+  'MAPPING_3_FIELD' => 'missing_ref',
+  'MAPPING_3_TYPE' => 'integer',
+  'MAPPING_3_NULL_TO_ZERO' => 'true',
+  'MAPPING_3_FORMULA' => '{MAPPING_99}',
+  #
+  # Virtual mapping: no topic, with positive/negative fields
+  'MAPPING_4_MEASUREMENT_POSITIVE' => 'PV',
+  'MAPPING_4_MEASUREMENT_NEGATIVE' => 'PV',
+  'MAPPING_4_FIELD_POSITIVE' => 'net_power_plus',
+  'MAPPING_4_FIELD_NEGATIVE' => 'net_power_minus',
+  'MAPPING_4_TYPE' => 'integer',
+  'MAPPING_4_FORMULA' => '{MAPPING_0} - {MAPPING_1}',
+}.freeze
+
 describe Mapper do
   subject(:mapper) { described_class.new(config:) }
 
@@ -516,5 +559,77 @@ describe Mapper do
     expect do
       mapper.records_for('this/is/an/unknown/topic', 'foo!')
     end.to raise_error(RuntimeError)
+  end
+
+  context 'with virtual mappings' do
+    subject(:mapper) { described_class.new(config:) }
+
+    let(:config) { Config.new(VIRTUAL_ENV, logger:) }
+    let(:logger) { MemoryLogger.new }
+
+    it 'does not subscribe to a topic for virtual mappings' do
+      expect(mapper.topics).to eq(
+        %w[
+          senec/0/ENERGY/GUI_HOUSE_POW
+          senec/0/ENERGY/GUI_INVERTER_POWER
+        ],
+      )
+    end
+
+    it 'lists virtual mappings' do
+      expect(mapper.virtual_mappings.map { |mapping| mapping[:mapping_group] }).to eq(
+        %w[2 3 4],
+      )
+    end
+
+    it 'formats a virtual mapping including its formula' do
+      expect(mapper.formatted_virtual_mapping(mapper.virtual_mappings[0])).to eq(
+        'PV:total_power (integer) = {MAPPING_0} + {MAPPING_1}',
+      )
+
+      expect(mapper.formatted_virtual_mapping(mapper.virtual_mappings[2])).to eq(
+        'PV:net_power_plus (+) PV:net_power_minus (-) (integer) = {MAPPING_0} - {MAPPING_1}',
+      )
+    end
+
+    it 'ignores the virtual mapping until all referenced values are known' do
+      hash = mapper.records_for('senec/0/ENERGY/GUI_INVERTER_POWER', '1000')
+
+      expect(hash).to eq(
+        [
+          { field: 'inverter_power', measurement: 'PV', value: 1000 },
+          { field: 'missing_ref', measurement: 'PV', value: 0 },
+        ],
+      )
+      expect(logger.warn_messages).to include(/Formula for total_power/)
+      expect(logger.warn_messages).to include(/Formula for net_power_plus/)
+    end
+
+    it 'calculates the virtual mapping once all referenced values are known, and keeps it updated' do
+      mapper.records_for('senec/0/ENERGY/GUI_INVERTER_POWER', '1000')
+
+      hash = mapper.records_for('senec/0/ENERGY/GUI_HOUSE_POW', '600')
+      expect(hash).to eq(
+        [
+          { field: 'house_power', measurement: 'PV', value: 600 },
+          { field: 'total_power', measurement: 'PV', value: 1600 },
+          { field: 'missing_ref', measurement: 'PV', value: 0 },
+          { field: 'net_power_minus', measurement: 'PV', value: 0 },
+          { field: 'net_power_plus', measurement: 'PV', value: 400 },
+        ],
+      )
+
+      # A later update of just one referenced mapping recalculates the virtual mapping
+      hash = mapper.records_for('senec/0/ENERGY/GUI_INVERTER_POWER', '2000')
+      expect(hash).to eq(
+        [
+          { field: 'inverter_power', measurement: 'PV', value: 2000 },
+          { field: 'total_power', measurement: 'PV', value: 2600 },
+          { field: 'missing_ref', measurement: 'PV', value: 0 },
+          { field: 'net_power_minus', measurement: 'PV', value: 0 },
+          { field: 'net_power_plus', measurement: 'PV', value: 1400 },
+        ],
+      )
+    end
   end
 end

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -352,6 +352,48 @@ SKIP_WRITE_ENV = {
   'MAPPING_3_SKIP_WRITE' => 'true',
 }.freeze
 
+DEDUP_ENV = {
+  'MQTT_HOST' => '1.2.3.4',
+  'MQTT_PORT' => '1883',
+  # ---
+  'INFLUX_HOST' => 'influx.example.com',
+  'INFLUX_SCHEMA' => 'https',
+  'INFLUX_PORT' => '443',
+  'INFLUX_TOKEN' => 'this.is.just.an.example',
+  'INFLUX_ORG' => 'solectrus',
+  'INFLUX_BUCKET' => 'my-bucket',
+  # ---
+  'MAPPING_0_TOPIC' => 'sensor/power',
+  'MAPPING_0_MEASUREMENT' => 'PV',
+  'MAPPING_0_FIELD' => 'power',
+  'MAPPING_0_TYPE' => 'integer',
+  'MAPPING_0_DEDUP' => 'true',
+  'MAPPING_0_HEARTBEAT_INTERVAL' => '60',
+  #
+  'MAPPING_1_TOPIC' => 'sensor/grid',
+  'MAPPING_1_MEASUREMENT_POSITIVE' => 'PV',
+  'MAPPING_1_MEASUREMENT_NEGATIVE' => 'PV',
+  'MAPPING_1_FIELD_POSITIVE' => 'grid_import',
+  'MAPPING_1_FIELD_NEGATIVE' => 'grid_export',
+  'MAPPING_1_TYPE' => 'integer',
+  'MAPPING_1_DEDUP' => 'true',
+  'MAPPING_1_HEARTBEAT_INTERVAL' => '60',
+  #
+  'MAPPING_2_TOPIC' => 'sensor/leak',
+  'MAPPING_2_MEASUREMENT' => 'Leak',
+  'MAPPING_2_FIELD' => 'detected',
+  'MAPPING_2_TYPE' => 'boolean',
+  'MAPPING_2_DEDUP' => 'true',
+  'MAPPING_2_HEARTBEAT_INTERVAL' => '60',
+  #
+  'MAPPING_3_TOPIC' => 'sensor/status',
+  'MAPPING_3_MEASUREMENT' => 'System',
+  'MAPPING_3_FIELD' => 'status',
+  'MAPPING_3_TYPE' => 'string',
+  'MAPPING_3_DEDUP' => 'true',
+  'MAPPING_3_HEARTBEAT_INTERVAL' => '60',
+}.freeze
+
 describe Mapper do
   subject(:mapper) { described_class.new(config:) }
 
@@ -969,6 +1011,140 @@ describe Mapper do
       expect(mapper.formatted_mapping('sensor/heatpump')).to eq(
         '(no InfluxDB field) (integer, not written to InfluxDB)',
       )
+    end
+  end
+
+  context 'with MAPPING_X_DEDUP' do
+    subject(:mapper) { described_class.new(config:) }
+
+    let(:config) { Config.new(DEDUP_ENV, logger:) }
+    let(:logger) { MemoryLogger.new }
+
+    def at(time)
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(time)
+    end
+
+    it 'always writes the first value, even if it is zero' do
+      at(1000.0)
+      hash = mapper.records_for('sensor/power', '0')
+
+      expect(hash).to eq([{ field: 'power', measurement: 'PV', value: 0 }])
+    end
+
+    it 'suppresses repeated zeros indefinitely, without a heartbeat' do
+      at(1000.0)
+      mapper.records_for('sensor/power', '0')
+
+      at(1000.0 + DEFAULT_HEARTBEAT_INTERVAL + 1)
+      hash = mapper.records_for('sensor/power', '0')
+
+      expect(hash).to eq([])
+    end
+
+    it 'always writes a value once it actually changes' do
+      at(1000.0)
+      mapper.records_for('sensor/power', '100')
+
+      at(1000.1)
+      hash = mapper.records_for('sensor/power', '200')
+
+      expect(hash).to eq([{ field: 'power', measurement: 'PV', value: 200 }])
+    end
+
+    it 'suppresses a repeated non-zero value within the heartbeat interval' do
+      at(1000.0)
+      mapper.records_for('sensor/power', '100')
+
+      at(1030.0) # 30s later - within the 60s heartbeat interval
+      hash = mapper.records_for('sensor/power', '100')
+
+      expect(hash).to eq([])
+    end
+
+    it 'writes a repeated non-zero value again once the heartbeat interval has passed' do
+      at(1000.0)
+      mapper.records_for('sensor/power', '100')
+
+      at(1061.0) # 61s later - beyond the 60s heartbeat interval
+      hash = mapper.records_for('sensor/power', '100')
+
+      expect(hash).to eq([{ field: 'power', measurement: 'PV', value: 100 }])
+    end
+
+    it 'treats each field of a positive/negative mapping independently' do
+      at(1000.0)
+      hash = mapper.records_for('sensor/grid', '100') # import
+      expect(hash).to eq(
+        [
+          { field: 'grid_export', measurement: 'PV', value: 0 },
+          { field: 'grid_import', measurement: 'PV', value: 100 },
+        ],
+      )
+
+      # grid_export stays at 0 (suppressed), grid_import changes - still written
+      at(1000.1)
+      hash = mapper.records_for('sensor/grid', '150')
+      expect(hash).to eq([{ field: 'grid_import', measurement: 'PV', value: 150 }])
+
+      # Now import goes quiet at 0, export becomes non-zero - both change, both written
+      at(1000.2)
+      hash = mapper.records_for('sensor/grid', '-50')
+      expect(hash).to eq(
+        [
+          { field: 'grid_export', measurement: 'PV', value: 50 },
+          { field: 'grid_import', measurement: 'PV', value: 0 },
+        ],
+      )
+
+      # grid_import (now 0) and grid_export (still 50) both repeat - suppressed within heartbeat
+      at(1000.3)
+      hash = mapper.records_for('sensor/grid', '-50')
+      expect(hash).to eq([])
+
+      # Well beyond the heartbeat interval - grid_export (non-zero) is written again,
+      # grid_import stays suppressed since it's zero
+      at(1061.0)
+      hash = mapper.records_for('sensor/grid', '-50')
+      expect(hash).to eq([{ field: 'grid_export', measurement: 'PV', value: 50 }])
+    end
+
+    it 'mentions dedup and the heartbeat interval in the formatted description' do
+      expect(mapper.formatted_mapping('sensor/power')).to eq(
+        'PV:power (integer, deduplicated (heartbeat 60s))',
+      )
+    end
+
+    it 'treats a repeated "false" boolean like a zero (suppressed indefinitely)' do
+      at(1000.0)
+      mapper.records_for('sensor/leak', 'false')
+
+      at(1000.0 + DEFAULT_HEARTBEAT_INTERVAL + 1)
+      hash = mapper.records_for('sensor/leak', 'false')
+
+      expect(hash).to eq([])
+    end
+
+    it 'still applies the heartbeat to a repeated "true" boolean' do
+      at(1000.0)
+      mapper.records_for('sensor/leak', 'true')
+
+      at(1061.0)
+      hash = mapper.records_for('sensor/leak', 'true')
+
+      expect(hash).to eq([{ field: 'detected', measurement: 'Leak', value: true }])
+    end
+
+    it 'still applies the heartbeat to a repeated string value (no zero-equivalent)' do
+      at(1000.0)
+      mapper.records_for('sensor/status', 'idle')
+
+      at(1030.0) # within the heartbeat interval - suppressed
+      hash = mapper.records_for('sensor/status', 'idle')
+      expect(hash).to eq([])
+
+      at(1061.0) # beyond the heartbeat interval - written again
+      hash = mapper.records_for('sensor/status', 'idle')
+      expect(hash).to eq([{ field: 'status', measurement: 'System', value: 'idle' }])
     end
   end
 end

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -259,6 +259,34 @@ MAX_AGE_ENV = {
   'MAPPING_3_TYPE' => 'integer',
 }.freeze
 
+LOGIC_ENV = {
+  'MQTT_HOST' => '1.2.3.4',
+  'MQTT_PORT' => '1883',
+  # ---
+  'INFLUX_HOST' => 'influx.example.com',
+  'INFLUX_SCHEMA' => 'https',
+  'INFLUX_PORT' => '443',
+  'INFLUX_TOKEN' => 'this.is.just.an.example',
+  'INFLUX_ORG' => 'solectrus',
+  'INFLUX_BUCKET' => 'my-bucket',
+  # ---
+  'MAPPING_0_TOPIC' => 'sensor/x',
+  'MAPPING_0_MEASUREMENT' => 'PV',
+  'MAPPING_0_FIELD' => 'x',
+  'MAPPING_0_TYPE' => 'integer',
+  #
+  'MAPPING_1_TOPIC' => 'sensor/y',
+  'MAPPING_1_MEASUREMENT' => 'PV',
+  'MAPPING_1_FIELD' => 'y',
+  'MAPPING_1_TYPE' => 'integer',
+  #
+  # Virtual mapping: no topic, uses IF() with a comparison across mappings
+  'MAPPING_2_MEASUREMENT' => 'PV',
+  'MAPPING_2_FIELD' => 'different',
+  'MAPPING_2_TYPE' => 'integer',
+  'MAPPING_2_FORMULA' => 'IF({MAPPING_0} != {MAPPING_1}, {MAPPING_0}, 0)',
+}.freeze
+
 describe Mapper do
   subject(:mapper) { described_class.new(config:) }
 
@@ -716,6 +744,44 @@ describe Mapper do
       )
       expect(logger.warn_messages).to include(
         %r{Formula for shadow_power.*MAPPING_0 \[sensor/power\]: never received.*MAPPING_1 \[sensor/other\]: never received},
+      )
+    end
+  end
+
+  context 'with a comparison operator (==, !=) in a virtual mapping formula' do
+    subject(:mapper) { described_class.new(config:) }
+
+    let(:config) { Config.new(LOGIC_ENV, logger:) }
+    let(:logger) { MemoryLogger.new }
+
+    it 'does not calculate the result before both sides are known' do
+      hash = mapper.records_for('sensor/x', '10')
+
+      expect(hash).to eq([{ field: 'x', measurement: 'PV', value: 10 }])
+    end
+
+    it 'returns 0 (the "else" branch) once both sides are known and equal' do
+      mapper.records_for('sensor/x', '10')
+      hash = mapper.records_for('sensor/y', '10')
+
+      expect(hash).to eq(
+        [
+          { field: 'y', measurement: 'PV', value: 10 },
+          { field: 'different', measurement: 'PV', value: 0 },
+        ],
+      )
+    end
+
+    it 'returns the mapping value (the "then" branch) once both sides differ' do
+      mapper.records_for('sensor/x', '10')
+      mapper.records_for('sensor/y', '10')
+      hash = mapper.records_for('sensor/x', '20')
+
+      expect(hash).to eq(
+        [
+          { field: 'x', measurement: 'PV', value: 20 },
+          { field: 'different', measurement: 'PV', value: 20 },
+        ],
       )
     end
   end

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -287,6 +287,37 @@ LOGIC_ENV = {
   'MAPPING_2_FORMULA' => 'IF({MAPPING_0} != {MAPPING_1}, {MAPPING_0}, 0)',
 }.freeze
 
+AGGREGATE_ENV = {
+  'MQTT_HOST' => '1.2.3.4',
+  'MQTT_PORT' => '1883',
+  # ---
+  'INFLUX_HOST' => 'influx.example.com',
+  'INFLUX_SCHEMA' => 'https',
+  'INFLUX_PORT' => '443',
+  'INFLUX_TOKEN' => 'this.is.just.an.example',
+  'INFLUX_ORG' => 'solectrus',
+  'INFLUX_BUCKET' => 'my-bucket',
+  # ---
+  'MAPPING_0_TOPIC' => 'sensor/fast',
+  'MAPPING_0_MEASUREMENT' => 'PV',
+  'MAPPING_0_FIELD' => 'fast_value',
+  'MAPPING_0_TYPE' => 'integer',
+  'MAPPING_0_AGGREGATE_INTERVAL' => '5',
+  #
+  'MAPPING_1_TOPIC' => 'sensor/plain',
+  'MAPPING_1_MEASUREMENT' => 'PV',
+  'MAPPING_1_FIELD' => 'plain_value',
+  'MAPPING_1_TYPE' => 'integer',
+  #
+  'MAPPING_2_TOPIC' => 'sensor/signed',
+  'MAPPING_2_MEASUREMENT_POSITIVE' => 'PV',
+  'MAPPING_2_MEASUREMENT_NEGATIVE' => 'PV',
+  'MAPPING_2_FIELD_POSITIVE' => 'signed_plus',
+  'MAPPING_2_FIELD_NEGATIVE' => 'signed_minus',
+  'MAPPING_2_TYPE' => 'integer',
+  'MAPPING_2_AGGREGATE_INTERVAL' => '5',
+}.freeze
+
 describe Mapper do
   subject(:mapper) { described_class.new(config:) }
 
@@ -781,6 +812,80 @@ describe Mapper do
         [
           { field: 'x', measurement: 'PV', value: 20 },
           { field: 'different', measurement: 'PV', value: 20 },
+        ],
+      )
+    end
+  end
+
+  context 'with MAPPING_X_AGGREGATE_INTERVAL' do
+    subject(:mapper) { described_class.new(config:) }
+
+    let(:config) { Config.new(AGGREGATE_ENV, logger:) }
+    let(:logger) { MemoryLogger.new }
+
+    def at(time)
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(time)
+    end
+
+    it 'does not affect a mapping without AGGREGATE_INTERVAL' do
+      at(1000.0)
+      hash = mapper.records_for('sensor/plain', '42')
+
+      expect(hash).to eq([{ field: 'plain_value', measurement: 'PV', value: 42 }])
+    end
+
+    it 'collects values without writing anything until the interval elapses' do
+      at(1000.0)
+      hash = mapper.records_for('sensor/fast', '10')
+      expect(hash).to eq([])
+
+      at(1002.0) # 2s later - still within the 5s window
+      hash = mapper.records_for('sensor/fast', '20')
+      expect(hash).to eq([])
+    end
+
+    it 'writes the average of all collected values once the interval elapses' do
+      at(1000.0)
+      mapper.records_for('sensor/fast', '10')
+
+      at(1002.0)
+      mapper.records_for('sensor/fast', '20')
+
+      at(1006.0) # 6s after the window started - beyond the 5s interval
+      hash = mapper.records_for('sensor/fast', '30')
+
+      # average of 10, 20, 30 == 20
+      expect(hash).to eq([{ field: 'fast_value', measurement: 'PV', value: 20 }])
+    end
+
+    it 'starts a fresh window after flushing, instead of carrying over old values' do
+      at(1000.0)
+      mapper.records_for('sensor/fast', '10')
+
+      at(1006.0)
+      mapper.records_for('sensor/fast', '20') # flushes average of [10, 20] == 15
+
+      at(1007.0) # new window just started - not yet due
+      hash = mapper.records_for('sensor/fast', '100')
+      expect(hash).to eq([])
+
+      at(1012.0) # 5s into the new window
+      hash = mapper.records_for('sensor/fast', '200')
+      expect(hash).to eq([{ field: 'fast_value', measurement: 'PV', value: 150 }])
+    end
+
+    it 'applies the aggregation before splitting into positive/negative fields' do
+      at(1000.0)
+      mapper.records_for('sensor/signed', '-10')
+
+      at(1006.0)
+      hash = mapper.records_for('sensor/signed', '30')
+
+      # average of -10 and 30 == 10 (positive)
+      expect(hash).to eq(
+        [
+          { field: 'signed_minus', measurement: 'PV', value: 0 },
+          { field: 'signed_plus', measurement: 'PV', value: 10 },
         ],
       )
     end

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -702,8 +702,9 @@ describe Mapper do
         [{ field: 'other', measurement: 'PV', value: 5 }],
       )
       expect(logger.warn_messages).to include(
-        %r{Formula for shadow_power could not be evaluated \(missing or outdated: MAPPING_0 \[sensor/power\]\)},
+        %r{Formula for shadow_power.*MAPPING_0 \[sensor/power\]: last received 31s ago},
       )
+      expect(logger.warn_messages).to include(/exceeds MAX_AGE of 30s/)
     end
 
     it 'names all missing or outdated references, not just the first one' do
@@ -714,7 +715,7 @@ describe Mapper do
         [{ field: 'decoy', measurement: 'PV', value: 1 }],
       )
       expect(logger.warn_messages).to include(
-        %r{Formula for shadow_power.*MAPPING_0 \[sensor/power\].*MAPPING_1 \[sensor/other\]},
+        %r{Formula for shadow_power.*MAPPING_0 \[sensor/power\]: never received.*MAPPING_1 \[sensor/other\]: never received},
       )
     end
   end


### PR DESCRIPTION
Hallo Georg,

da gestern sowohl mein Homeassistant für mehrere Stunden, sowie ioBroker ausgefallen sind(Ursache noch ungeklärt), haben meine berechneten Sensoren gefehlt. Das hat mich wieder auf mein damaliges Issue gebracht im MQTT-Collector "Virtuelle Mappings" zu verarbeiten. Daraufhin habe ich mal etwas gespielt und es kam folgendes dabei raus:

- Virtuelle Mappings sind jetzt möglich. Es wird eine Meldung ausgegeben, wenn ein Mapping-Wert fehlt und erst bei Vollständigkeit geschickt
- Die Sensoren, die dazu nötig sind müssen nicht extra an Influx geschickt werden und können mit ** SKIP_WRITE** nur intern verabeitet werden. Measurement und Field sind dann optional
- Zusätzlich können Werte mit **MAX_AGE** geprüft werden, da bei virtuellen Mappings der Ausfall eines sonst nicht auffallen würde, solange ein Wert ansteht. 
- Zu häufige Wertänderungen(sehe ich gerade beim Netzwerk-Shelly) können per **AGGREGATE_INTERVAL** verarbeitet und der Durchschnitt gesendet werden.
- Identische Werte können ebenfalls anders behandelt werden. Mit **DEDUP + HEARTBEAT_INTERVAL** werden 0 Werte nur einmalig gesendet und identische Werte > 0 nach eingestelltem Intervall. Wertänderung werden sofort übertragen
- Die Influx-Verbindung wird jetzt geprüft. Bei Unterbrechung werden die Werte gecached und bei Wiederherstellung nachträglich geschickt(analog Senec- und Shelly-Collector)
- Die Dokumentation habe ich zu den Änderungen angepasst.

Schaus dir gerne mal an und probiers aus. Sei ruhig ehrlich, was du davon hältst :) Bei mir laufen aktuell drei Berechnungen, die ich mit ioBroker vergleiche. Sieht bisher gut aus :)

PS: Ich habe im .github-Ordner die Dateien etwas modifiziert, damit ich Docker-Builds auf meinem Branch erstellen konnte. Das müsste dann, falls überhaupt gewünscht, wieder glattgezogen werden.

Schönen Abend!