### PR TITLE
Add MAPPING_X_AGGREGATE_INTERVAL, SKIP_WRITE and DEDUP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ MQTT_PASSWORD=my-mqtt-password
 # - MAPPING_X_AGGREGATE_INTERVAL: instead of writing every single value to InfluxDB, collect
 #   values for this many seconds and write their average once the interval has elapsed
 #   (optional, useful to throttle down high-frequency topics)
+# - MAPPING_X_SKIP_WRITE: set to "true" to process this mapping's value (e.g. to keep it
+#   available for MAX_AGE tracking and virtual mapping formulas), without ever writing it to
+#   InfluxDB itself (optional, useful for raw sensors that only feed a virtual mapping)
 #
 #
 # Here are some examples of mappings:
@@ -163,6 +166,13 @@ MQTT_PASSWORD=my-mqtt-password
 # formula that references a name nobody defined (e.g. a typo) - there's nothing to distinguish
 # that from "not received yet", so check the warning message (see below) if a virtual mapping
 # never seems to produce a value.
+#
+# If you only care about the calculated total and don't want the raw sensors cluttering
+# InfluxDB, add MAPPING_X_SKIP_WRITE=true to MAPPING_8 and MAPPING_9 above - their values are
+# still tracked in memory and used by the total_power formula, they're just never written
+# themselves:
+#   MAPPING_8_SKIP_WRITE=true
+#   MAPPING_9_SKIP_WRITE=true
 #
 # If a sensor stops sending updates (e.g. due to a connection loss), its last known value would
 # otherwise be reused forever by any virtual mapping that references it - silently producing

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,12 @@ MQTT_PASSWORD=my-mqtt-password
 # - MAPPING_X_SKIP_WRITE: set to "true" to process this mapping's value (e.g. to keep it
 #   available for MAX_AGE tracking and virtual mapping formulas), without ever writing it to
 #   InfluxDB itself (optional, useful for raw sensors that only feed a virtual mapping)
+# - MAPPING_X_DEDUP: set to "true" to skip writing a value that's unchanged from the last one
+#   written. A repeated zero is suppressed indefinitely (written once, then ignored until it
+#   changes); a repeated non-zero value is still written periodically (see
+#   MAPPING_X_HEARTBEAT_INTERVAL below), to show that the sender is still active (optional)
+# - MAPPING_X_HEARTBEAT_INTERVAL: how many seconds a repeated non-zero value may be suppressed
+#   by MAPPING_X_DEDUP before it's written again anyway (optional, defaults to 60)
 #
 #
 # Here are some examples of mappings:
@@ -198,6 +204,21 @@ MQTT_PASSWORD=my-mqtt-password
 # The "never received" case fires immediately (e.g. right after a restart, when the in-memory
 # cache is still empty) and is unrelated to MAX_AGE - only "last received ... exceeds MAX_AGE ..."
 # means the value actually expired.
+#
+# Mapping that skips writing unchanged values, to avoid flooding InfluxDB with duplicates:
+#   MAPPING_12_TOPIC=my/leak-sensor/state
+#   MAPPING_12_MEASUREMENT=Leak
+#   MAPPING_12_FIELD=detected
+#   MAPPING_12_TYPE=boolean
+#   MAPPING_12_DEDUP=true
+#   MAPPING_12_HEARTBEAT_INTERVAL=60
+#
+# As long as the value keeps arriving as "false" (or 0, for numeric types), it's written once and
+# then ignored - no further signal is needed. Once it becomes "true" (or non-zero), that change is
+# always written immediately, and then re-written every 60 seconds for as long as it stays "true" -
+# so a monitoring dashboard can tell "still true" apart from "sender has gone silent".
+# This applies per written field, so a MEASUREMENT_POSITIVE/NEGATIVE mapping is deduplicated
+# independently for each of the two fields.
 
 MAPPING_0_TOPIC=senec/0/ENERGY/GUI_INVERTER_POWER
 MAPPING_0_MEASUREMENT=PV

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ MQTT_PASSWORD=my-mqtt-password
 # - MAPPING_X_MAX_AGE: how many seconds this mapping's value stays valid for use in a virtual
 #   mapping's formula, after which it's treated as unknown instead of stale. Requires
 #   MAPPING_X_NAME to be set (optional)
+# - MAPPING_X_AGGREGATE_INTERVAL: instead of writing every single value to InfluxDB, collect
+#   values for this many seconds and write their average once the interval has elapsed
+#   (optional, useful to throttle down high-frequency topics)
 #
 #
 # Here are some examples of mappings:
@@ -110,6 +113,19 @@ MQTT_PASSWORD=my-mqtt-password
 #   MAPPING_7_FORMULA="{value} * 1000"
 #
 # (just use the `{value}` placeholder to reference the value)
+#
+# Mapping that throttles a high-frequency topic down to one write every 5 seconds:
+#   MAPPING_12_TOPIC=my/fast-changing/power
+#   MAPPING_12_MEASUREMENT=Fast
+#   MAPPING_12_FIELD=power
+#   MAPPING_12_TYPE=float
+#   MAPPING_12_AGGREGATE_INTERVAL=5
+#
+# If messages for this topic arrive every second, they're collected in memory and only their
+# average is written to InfluxDB once every 5 seconds, instead of writing every single value.
+# The 5-second window starts with the first value received, and a new window begins right after
+# each write - so writes happen every ~5s as long as new values keep arriving, not on a fixed
+# wall-clock schedule.
 #
 # Virtual mapping (calculates a value from other mappings, without its own MQTT topic):
 #   MAPPING_8_TOPIC=my/washing-machine/power

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -198,6 +198,10 @@ class Config
         validate_mapping!(index, :null_to_zero, allow_list: %w[true false])
       end
 
+      if mapping[:skip_write]
+        validate_mapping!(index, :skip_write, allow_list: %w[true false])
+      end
+
       validate_name!(index)
       validate_max_age!(mapping)
       validate_destination!(mapping, index)

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -216,7 +216,10 @@ class Config
           "MAPPING_#{mapping[:mapping_group]}_NAME to be set"
   end
 
+  # A mapping that's never written to InfluxDB doesn't need a destination
   def validate_destination!(mapping, index)
+    return if mapping[:skip_write] == 'true'
+
     if mapping[:field_positive] || mapping[:field_negative]
       validate_mapping!(index, :field_positive)
       validate_mapping!(index, :field_negative)

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -202,6 +202,10 @@ class Config
         validate_mapping!(index, :skip_write, allow_list: %w[true false])
       end
 
+      if mapping[:dedup]
+        validate_mapping!(index, :dedup, allow_list: %w[true false])
+      end
+
       validate_name!(index)
       validate_max_age!(mapping)
       validate_destination!(mapping, index)

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -185,6 +185,10 @@ class Mapper
     @aggregation_buffers ||= {}
   end
 
+  def mapping_key(mapping)
+    "MAPPING_#{mapping[:mapping_group]}"
+  end
+
   def virtual_value_from(mapping)
     message = Evaluator.new(expression: mapping[:formula], data: fresh_values).run
 

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -40,15 +40,7 @@ class Mapper
   private
 
   def describe_mapping(mapping)
-    result =
-      if signed?(mapping)
-        "#{mapping[:measurement_positive]}:#{mapping[:field_positive]} (+) " \
-          "#{mapping[:measurement_negative]}:#{mapping[:field_negative]} (-)"
-      else
-        "#{mapping[:measurement]}:#{mapping[:field]}"
-      end
-
-    result + ' (' \
+    mapping_target(mapping) + ' (' \
              "#{"#{mapping[:min]} ≥ " if mapping[:min]}#{mapping[:type]}" \
              "#{" ≤ #{mapping[:max]}" if mapping[:max]}" \
              "#{', converting NULL to 0' if mapping[:null_to_zero] == 'true'}" \
@@ -56,6 +48,17 @@ class Mapper
              "#{", averaged every #{mapping[:aggregate_interval]}s" if mapping[:aggregate_interval]}" \
              "#{', not written to InfluxDB' if mapping[:skip_write] == 'true'}" \
              ')'
+  end
+
+  def mapping_target(mapping)
+    if signed?(mapping)
+      "#{mapping[:measurement_positive]}:#{mapping[:field_positive]} (+) " \
+        "#{mapping[:measurement_negative]}:#{mapping[:field_negative]} (-)"
+    elsif mapping[:measurement] || mapping[:field]
+      "#{mapping[:measurement]}:#{mapping[:field]}"
+    else
+      '(no InfluxDB field)'
+    end
   end
 
   def records_for_mapping(mapping, message)

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -1,5 +1,7 @@
 require 'evaluator'
 
+DEFAULT_HEARTBEAT_INTERVAL = 60
+
 class Mapper
   def initialize(config:)
     @config = config
@@ -47,7 +49,14 @@ class Mapper
              "#{", named '#{mapping[:name]}'" if mapping[:name]}" \
              "#{", averaged every #{mapping[:aggregate_interval]}s" if mapping[:aggregate_interval]}" \
              "#{', not written to InfluxDB' if mapping[:skip_write] == 'true'}" \
+             "#{dedup_description(mapping)}" \
              ')'
+  end
+
+  def dedup_description(mapping)
+    return '' unless mapping[:dedup] == 'true'
+
+    ", deduplicated (heartbeat #{mapping[:heartbeat_interval] || DEFAULT_HEARTBEAT_INTERVAL}s)"
   end
 
   def mapping_target(mapping)
@@ -86,11 +95,58 @@ class Mapper
     value = throttled(mapping, value)
     return [] if value.nil?
 
-    if signed?(mapping)
-      map_with_sign(mapping, value)
-    else
-      map_default(mapping, value)
+    records =
+      if signed?(mapping)
+        map_with_sign(mapping, value)
+      else
+        map_default(mapping, value)
+      end
+
+    deduped(mapping, records)
+  end
+
+  # If MAPPING_X_DEDUP is set, a record is only passed through when its value
+  # actually changed - except a zero value is always written once and then
+  # suppressed for as long as it stays zero (no further signal needed), while
+  # a repeated non-zero value is still written every MAPPING_X_HEARTBEAT_INTERVAL
+  # seconds (default 60), to show that the sender is still alive.
+  def deduped(mapping, records)
+    return records unless mapping[:dedup] == 'true'
+
+    interval = (mapping[:heartbeat_interval] || DEFAULT_HEARTBEAT_INTERVAL).to_f
+    records.select { |record| due_for_write?(record, interval) }
+  end
+
+  def due_for_write?(record, interval)
+    key = [record[:measurement], record[:field]]
+    last = dedup_state[key]
+
+    if last.nil? || last[:value] != record[:value]
+      dedup_state[key] = { value: record[:value], written_at: monotonic_time }
+      return true
     end
+
+    return false if zero_ish?(record[:value])
+
+    return false if monotonic_time - last[:written_at] < interval
+
+    last[:written_at] = monotonic_time
+    true
+  end
+
+  def zero_ish?(value)
+    case value
+    when Numeric
+      value.zero?
+    when true, false
+      value == false
+    else
+      false
+    end
+  end
+
+  def dedup_state
+    @dedup_state ||= {}
   end
 
   # If MAPPING_X_AGGREGATE_INTERVAL is set, don't pass every single value

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -54,6 +54,7 @@ class Mapper
              "#{', converting NULL to 0' if mapping[:null_to_zero] == 'true'}" \
              "#{", named '#{mapping[:name]}'" if mapping[:name]}" \
              "#{", averaged every #{mapping[:aggregate_interval]}s" if mapping[:aggregate_interval]}" \
+             "#{', not written to InfluxDB' if mapping[:skip_write] == 'true'}" \
              ')'
   end
 
@@ -77,6 +78,7 @@ class Mapper
 
   def records_from(mapping, value)
     return [] if value.nil?
+    return [] if mapping[:skip_write] == 'true'
 
     value = throttled(mapping, value)
     return [] if value.nil?

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -53,6 +53,7 @@ class Mapper
              "#{" ≤ #{mapping[:max]}" if mapping[:max]}" \
              "#{', converting NULL to 0' if mapping[:null_to_zero] == 'true'}" \
              "#{", named '#{mapping[:name]}'" if mapping[:name]}" \
+             "#{", averaged every #{mapping[:aggregate_interval]}s" if mapping[:aggregate_interval]}" \
              ')'
   end
 
@@ -60,11 +61,7 @@ class Mapper
     value = value_from(message, mapping)
     remember_value(mapping, value)
 
-    if value && signed?(mapping)
-      map_with_sign(mapping, value)
-    else
-      map_default(mapping, value)
-    end
+    records_from(mapping, value)
   end
 
   # Recalculate all virtual mappings, since any of them might reference a
@@ -74,12 +71,57 @@ class Mapper
       value = virtual_value_from(mapping)
       remember_value(mapping, value)
 
-      if value && signed?(mapping)
-        map_with_sign(mapping, value)
-      else
-        map_default(mapping, value)
-      end
+      records_from(mapping, value)
     end
+  end
+
+  def records_from(mapping, value)
+    return [] if value.nil?
+
+    value = throttled(mapping, value)
+    return [] if value.nil?
+
+    if signed?(mapping)
+      map_with_sign(mapping, value)
+    else
+      map_default(mapping, value)
+    end
+  end
+
+  # If MAPPING_X_AGGREGATE_INTERVAL is set, don't pass every single value
+  # through - instead collect them and only return the average once the
+  # interval has passed, so high-frequency updates get throttled down to one
+  # write per interval. Returns the value unchanged if no interval is set.
+  def throttled(mapping, value)
+    interval = mapping[:aggregate_interval]&.to_f
+    return value unless interval
+
+    average = aggregate(mapping_key(mapping), value, interval)
+    return nil if average.nil?
+
+    convert_type(average, mapping)
+  end
+
+  # Collects values per mapping in a fixed window starting with the first
+  # value received for it. Returns nil while the window is still open, or the
+  # average of all values collected so far once the interval has elapsed -
+  # at which point the window resets, to start fresh with the next value.
+  def aggregate(key, value, interval)
+    now = monotonic_time
+    buffer = (aggregation_buffers[key] ||= { sum: 0.0, count: 0, window_start: now })
+
+    buffer[:sum] += value
+    buffer[:count] += 1
+
+    return nil if now - buffer[:window_start] < interval
+
+    average = buffer[:sum] / buffer[:count]
+    aggregation_buffers.delete(key)
+    average
+  end
+
+  def aggregation_buffers
+    @aggregation_buffers ||= {}
   end
 
   def virtual_value_from(mapping)

--- a/spec/lib/config_mapping_spec.rb
+++ b/spec/lib/config_mapping_spec.rb
@@ -175,4 +175,29 @@ describe Config, '#mapping' do
       expect(original_formula[:formula]).to eq(renumbered_formula[:formula])
     end
   end
+
+  context 'with a SKIP_WRITE mapping that omits FIELD and MEASUREMENT' do
+    let(:env) do
+      other_env.merge(
+        {
+          'MAPPING_0_TOPIC' => 'senec/0/ENERGY/GUI_INVERTER_POWER',
+          'MAPPING_0_TYPE' => 'integer',
+          'MAPPING_0_SKIP_WRITE' => 'true',
+        },
+      )
+    end
+
+    it 'does not raise, since the value is never written to InfluxDB' do
+      expect(mappings).to eq(
+        [
+          {
+            topic: 'senec/0/ENERGY/GUI_INVERTER_POWER',
+            type: 'integer',
+            skip_write: 'true',
+            mapping_group: '0',
+          },
+        ],
+      )
+    end
+  end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -529,6 +529,9 @@ describe Config do
       # Invalid skip_write
       [:merge, { 'MAPPING_0_SKIP_WRITE' => 'this-is-no-boolean' },
        'Variable MAPPING_0_SKIP_WRITE is invalid: this-is-no-boolean. Must be one of: true, false',],
+      # Invalid dedup
+      [:merge, { 'MAPPING_0_DEDUP' => 'this-is-no-boolean' },
+       'Variable MAPPING_0_DEDUP is invalid: this-is-no-boolean. Must be one of: true, false',],
     ].each do |method_name, argument, error_message|
       it "raises a Config::Error ('#{error_message}')" do
         env = valid_env.public_send(method_name, argument)

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -526,6 +526,9 @@ describe Config do
       # max_age requires a name
       [:merge, { 'MAPPING_0_MAX_AGE' => '60' },
        'Variable MAPPING_0_MAX_AGE requires MAPPING_0_NAME to be set',],
+      # Invalid skip_write
+      [:merge, { 'MAPPING_0_SKIP_WRITE' => 'this-is-no-boolean' },
+       'Variable MAPPING_0_SKIP_WRITE is invalid: this-is-no-boolean. Must be one of: true, false',],
     ].each do |method_name, argument, error_message|
       it "raises a Config::Error ('#{error_message}')" do
         env = valid_env.public_send(method_name, argument)

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -351,6 +351,11 @@ SKIP_WRITE_ENV = {
   'MAPPING_2_FIELD' => 'total_power',
   'MAPPING_2_TYPE' => 'integer',
   'MAPPING_2_FORMULA' => '{MAPPING_0} + {MAPPING_1}',
+  #
+  # Skipped mapping without FIELD/MEASUREMENT at all - only feeds MAPPING_2
+  'MAPPING_3_TOPIC' => 'sensor/heatpump',
+  'MAPPING_3_TYPE' => 'integer',
+  'MAPPING_3_SKIP_WRITE' => 'true',
 }.freeze
 
 describe Mapper do
@@ -961,6 +966,15 @@ describe Mapper do
         'Washer:power (integer, not written to InfluxDB)',
       )
       expect(mapper.formatted_mapping('sensor/dryer')).to eq('Dryer:power (integer)')
+    end
+
+    it 'does not require FIELD/MEASUREMENT for a skipped mapping' do
+      hash = mapper.records_for('sensor/heatpump', '42')
+
+      expect(hash).to eq([])
+      expect(mapper.formatted_mapping('sensor/heatpump')).to eq(
+        '(no InfluxDB field) (integer, not written to InfluxDB)',
+      )
     end
   end
 end

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -358,6 +358,48 @@ SKIP_WRITE_ENV = {
   'MAPPING_3_SKIP_WRITE' => 'true',
 }.freeze
 
+DEDUP_ENV = {
+  'MQTT_HOST' => '1.2.3.4',
+  'MQTT_PORT' => '1883',
+  # ---
+  'INFLUX_HOST' => 'influx.example.com',
+  'INFLUX_SCHEMA' => 'https',
+  'INFLUX_PORT' => '443',
+  'INFLUX_TOKEN' => 'this.is.just.an.example',
+  'INFLUX_ORG' => 'solectrus',
+  'INFLUX_BUCKET' => 'my-bucket',
+  # ---
+  'MAPPING_0_TOPIC' => 'sensor/power',
+  'MAPPING_0_MEASUREMENT' => 'PV',
+  'MAPPING_0_FIELD' => 'power',
+  'MAPPING_0_TYPE' => 'integer',
+  'MAPPING_0_DEDUP' => 'true',
+  'MAPPING_0_HEARTBEAT_INTERVAL' => '60',
+  #
+  'MAPPING_1_TOPIC' => 'sensor/grid',
+  'MAPPING_1_MEASUREMENT_POSITIVE' => 'PV',
+  'MAPPING_1_MEASUREMENT_NEGATIVE' => 'PV',
+  'MAPPING_1_FIELD_POSITIVE' => 'grid_import',
+  'MAPPING_1_FIELD_NEGATIVE' => 'grid_export',
+  'MAPPING_1_TYPE' => 'integer',
+  'MAPPING_1_DEDUP' => 'true',
+  'MAPPING_1_HEARTBEAT_INTERVAL' => '60',
+  #
+  'MAPPING_2_TOPIC' => 'sensor/leak',
+  'MAPPING_2_MEASUREMENT' => 'Leak',
+  'MAPPING_2_FIELD' => 'detected',
+  'MAPPING_2_TYPE' => 'boolean',
+  'MAPPING_2_DEDUP' => 'true',
+  'MAPPING_2_HEARTBEAT_INTERVAL' => '60',
+  #
+  'MAPPING_3_TOPIC' => 'sensor/status',
+  'MAPPING_3_MEASUREMENT' => 'System',
+  'MAPPING_3_FIELD' => 'status',
+  'MAPPING_3_TYPE' => 'string',
+  'MAPPING_3_DEDUP' => 'true',
+  'MAPPING_3_HEARTBEAT_INTERVAL' => '60',
+}.freeze
+
 describe Mapper do
   subject(:mapper) { described_class.new(config:) }
 
@@ -975,6 +1017,140 @@ describe Mapper do
       expect(mapper.formatted_mapping('sensor/heatpump')).to eq(
         '(no InfluxDB field) (integer, not written to InfluxDB)',
       )
+    end
+  end
+
+  context 'with MAPPING_X_DEDUP' do
+    subject(:mapper) { described_class.new(config:) }
+
+    let(:config) { Config.new(DEDUP_ENV, logger:) }
+    let(:logger) { MemoryLogger.new }
+
+    def at(time)
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(time)
+    end
+
+    it 'always writes the first value, even if it is zero' do
+      at(1000.0)
+      hash = mapper.records_for('sensor/power', '0')
+
+      expect(hash).to eq([{ field: 'power', measurement: 'PV', value: 0 }])
+    end
+
+    it 'suppresses repeated zeros indefinitely, without a heartbeat' do
+      at(1000.0)
+      mapper.records_for('sensor/power', '0')
+
+      at(1000.0 + DEFAULT_HEARTBEAT_INTERVAL + 1)
+      hash = mapper.records_for('sensor/power', '0')
+
+      expect(hash).to eq([])
+    end
+
+    it 'always writes a value once it actually changes' do
+      at(1000.0)
+      mapper.records_for('sensor/power', '100')
+
+      at(1000.1)
+      hash = mapper.records_for('sensor/power', '200')
+
+      expect(hash).to eq([{ field: 'power', measurement: 'PV', value: 200 }])
+    end
+
+    it 'suppresses a repeated non-zero value within the heartbeat interval' do
+      at(1000.0)
+      mapper.records_for('sensor/power', '100')
+
+      at(1030.0) # 30s later - within the 60s heartbeat interval
+      hash = mapper.records_for('sensor/power', '100')
+
+      expect(hash).to eq([])
+    end
+
+    it 'writes a repeated non-zero value again once the heartbeat interval has passed' do
+      at(1000.0)
+      mapper.records_for('sensor/power', '100')
+
+      at(1061.0) # 61s later - beyond the 60s heartbeat interval
+      hash = mapper.records_for('sensor/power', '100')
+
+      expect(hash).to eq([{ field: 'power', measurement: 'PV', value: 100 }])
+    end
+
+    it 'treats each field of a positive/negative mapping independently' do
+      at(1000.0)
+      hash = mapper.records_for('sensor/grid', '100') # import
+      expect(hash).to eq(
+        [
+          { field: 'grid_export', measurement: 'PV', value: 0 },
+          { field: 'grid_import', measurement: 'PV', value: 100 },
+        ],
+      )
+
+      # grid_export stays at 0 (suppressed), grid_import changes - still written
+      at(1000.1)
+      hash = mapper.records_for('sensor/grid', '150')
+      expect(hash).to eq([{ field: 'grid_import', measurement: 'PV', value: 150 }])
+
+      # Now import goes quiet at 0, export becomes non-zero - both change, both written
+      at(1000.2)
+      hash = mapper.records_for('sensor/grid', '-50')
+      expect(hash).to eq(
+        [
+          { field: 'grid_export', measurement: 'PV', value: 50 },
+          { field: 'grid_import', measurement: 'PV', value: 0 },
+        ],
+      )
+
+      # grid_import (now 0) and grid_export (still 50) both repeat - suppressed within heartbeat
+      at(1000.3)
+      hash = mapper.records_for('sensor/grid', '-50')
+      expect(hash).to eq([])
+
+      # Well beyond the heartbeat interval - grid_export (non-zero) is written again,
+      # grid_import stays suppressed since it's zero
+      at(1061.0)
+      hash = mapper.records_for('sensor/grid', '-50')
+      expect(hash).to eq([{ field: 'grid_export', measurement: 'PV', value: 50 }])
+    end
+
+    it 'mentions dedup and the heartbeat interval in the formatted description' do
+      expect(mapper.formatted_mapping('sensor/power')).to eq(
+        'PV:power (integer, deduplicated (heartbeat 60s))',
+      )
+    end
+
+    it 'treats a repeated "false" boolean like a zero (suppressed indefinitely)' do
+      at(1000.0)
+      mapper.records_for('sensor/leak', 'false')
+
+      at(1000.0 + DEFAULT_HEARTBEAT_INTERVAL + 1)
+      hash = mapper.records_for('sensor/leak', 'false')
+
+      expect(hash).to eq([])
+    end
+
+    it 'still applies the heartbeat to a repeated "true" boolean' do
+      at(1000.0)
+      mapper.records_for('sensor/leak', 'true')
+
+      at(1061.0)
+      hash = mapper.records_for('sensor/leak', 'true')
+
+      expect(hash).to eq([{ field: 'detected', measurement: 'Leak', value: true }])
+    end
+
+    it 'still applies the heartbeat to a repeated string value (no zero-equivalent)' do
+      at(1000.0)
+      mapper.records_for('sensor/status', 'idle')
+
+      at(1030.0) # within the heartbeat interval - suppressed
+      hash = mapper.records_for('sensor/status', 'idle')
+      expect(hash).to eq([])
+
+      at(1061.0) # beyond the heartbeat interval - written again
+      hash = mapper.records_for('sensor/status', 'idle')
+      expect(hash).to eq([{ field: 'status', measurement: 'System', value: 'idle' }])
     end
   end
 end

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -324,6 +324,35 @@ AGGREGATE_ENV = {
   'MAPPING_2_AGGREGATE_INTERVAL' => '5',
 }.freeze
 
+SKIP_WRITE_ENV = {
+  'MQTT_HOST' => '1.2.3.4',
+  'MQTT_PORT' => '1883',
+  # ---
+  'INFLUX_HOST' => 'influx.example.com',
+  'INFLUX_SCHEMA' => 'https',
+  'INFLUX_PORT' => '443',
+  'INFLUX_TOKEN' => 'this.is.just.an.example',
+  'INFLUX_ORG' => 'solectrus',
+  'INFLUX_BUCKET' => 'my-bucket',
+  # ---
+  'MAPPING_0_TOPIC' => 'sensor/washer',
+  'MAPPING_0_MEASUREMENT' => 'Washer',
+  'MAPPING_0_FIELD' => 'power',
+  'MAPPING_0_TYPE' => 'integer',
+  'MAPPING_0_SKIP_WRITE' => 'true',
+  #
+  'MAPPING_1_TOPIC' => 'sensor/dryer',
+  'MAPPING_1_MEASUREMENT' => 'Dryer',
+  'MAPPING_1_FIELD' => 'power',
+  'MAPPING_1_TYPE' => 'integer',
+  #
+  # Virtual mapping: no topic, calculated from MAPPING_0 (skipped) and MAPPING_1 (written)
+  'MAPPING_2_MEASUREMENT' => 'Household',
+  'MAPPING_2_FIELD' => 'total_power',
+  'MAPPING_2_TYPE' => 'integer',
+  'MAPPING_2_FORMULA' => '{MAPPING_0} + {MAPPING_1}',
+}.freeze
+
 describe Mapper do
   subject(:mapper) { described_class.new(config:) }
 
@@ -894,6 +923,44 @@ describe Mapper do
           { field: 'signed_plus', measurement: 'PV', value: 10 },
         ],
       )
+    end
+  end
+
+  context 'with MAPPING_X_SKIP_WRITE' do
+    subject(:mapper) { described_class.new(config:) }
+
+    let(:config) { Config.new(SKIP_WRITE_ENV, logger:) }
+    let(:logger) { MemoryLogger.new }
+
+    it 'does not write the skipped mapping, but still writes a regular one' do
+      hash = mapper.records_for('sensor/dryer', '500')
+
+      expect(hash).to eq([{ field: 'power', measurement: 'Dryer', value: 500 }])
+    end
+
+    it 'never writes the skipped mapping, even alone on its own topic' do
+      hash = mapper.records_for('sensor/washer', '300')
+
+      expect(hash).to eq([])
+    end
+
+    it 'still uses the skipped mapping value in a virtual mapping formula' do
+      mapper.records_for('sensor/washer', '300')
+      hash = mapper.records_for('sensor/dryer', '500')
+
+      expect(hash).to eq(
+        [
+          { field: 'power', measurement: 'Dryer', value: 500 },
+          { field: 'total_power', measurement: 'Household', value: 800 },
+        ],
+      )
+    end
+
+    it 'mentions skipped mappings in the formatted description' do
+      expect(mapper.formatted_mapping('sensor/washer')).to eq(
+        'Washer:power (integer, not written to InfluxDB)',
+      )
+      expect(mapper.formatted_mapping('sensor/dryer')).to eq('Dryer:power (integer)')
     end
   end
 end

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -340,17 +340,19 @@ SKIP_WRITE_ENV = {
   'MAPPING_0_FIELD' => 'power',
   'MAPPING_0_TYPE' => 'integer',
   'MAPPING_0_SKIP_WRITE' => 'true',
+  'MAPPING_0_NAME' => 'washer',
   #
   'MAPPING_1_TOPIC' => 'sensor/dryer',
   'MAPPING_1_MEASUREMENT' => 'Dryer',
   'MAPPING_1_FIELD' => 'power',
   'MAPPING_1_TYPE' => 'integer',
+  'MAPPING_1_NAME' => 'dryer',
   #
   # Virtual mapping: no topic, calculated from MAPPING_0 (skipped) and MAPPING_1 (written)
   'MAPPING_2_MEASUREMENT' => 'Household',
   'MAPPING_2_FIELD' => 'total_power',
   'MAPPING_2_TYPE' => 'integer',
-  'MAPPING_2_FORMULA' => '{MAPPING_0} + {MAPPING_1}',
+  'MAPPING_2_FORMULA' => '{washer} + {dryer}',
   #
   # Skipped mapping without FIELD/MEASUREMENT at all - only feeds MAPPING_2
   'MAPPING_3_TOPIC' => 'sensor/heatpump',
@@ -1005,9 +1007,9 @@ describe Mapper do
 
     it 'mentions skipped mappings in the formatted description' do
       expect(mapper.formatted_mapping('sensor/washer')).to eq(
-        'Washer:power (integer, not written to InfluxDB)',
+        "Washer:power (integer, named 'washer', not written to InfluxDB)",
       )
-      expect(mapper.formatted_mapping('sensor/dryer')).to eq('Dryer:power (integer)')
+      expect(mapper.formatted_mapping('sensor/dryer')).to eq("Dryer:power (integer, named 'dryer')")
     end
 
     it 'does not require FIELD/MEASUREMENT for a skipped mapping' do

--- a/spec/lib/mapper_spec.rb
+++ b/spec/lib/mapper_spec.rb
@@ -293,6 +293,37 @@ LOGIC_ENV = {
   'MAPPING_2_FORMULA' => 'IF({x} != {y}, {x}, 0)',
 }.freeze
 
+AGGREGATE_ENV = {
+  'MQTT_HOST' => '1.2.3.4',
+  'MQTT_PORT' => '1883',
+  # ---
+  'INFLUX_HOST' => 'influx.example.com',
+  'INFLUX_SCHEMA' => 'https',
+  'INFLUX_PORT' => '443',
+  'INFLUX_TOKEN' => 'this.is.just.an.example',
+  'INFLUX_ORG' => 'solectrus',
+  'INFLUX_BUCKET' => 'my-bucket',
+  # ---
+  'MAPPING_0_TOPIC' => 'sensor/fast',
+  'MAPPING_0_MEASUREMENT' => 'PV',
+  'MAPPING_0_FIELD' => 'fast_value',
+  'MAPPING_0_TYPE' => 'integer',
+  'MAPPING_0_AGGREGATE_INTERVAL' => '5',
+  #
+  'MAPPING_1_TOPIC' => 'sensor/plain',
+  'MAPPING_1_MEASUREMENT' => 'PV',
+  'MAPPING_1_FIELD' => 'plain_value',
+  'MAPPING_1_TYPE' => 'integer',
+  #
+  'MAPPING_2_TOPIC' => 'sensor/signed',
+  'MAPPING_2_MEASUREMENT_POSITIVE' => 'PV',
+  'MAPPING_2_MEASUREMENT_NEGATIVE' => 'PV',
+  'MAPPING_2_FIELD_POSITIVE' => 'signed_plus',
+  'MAPPING_2_FIELD_NEGATIVE' => 'signed_minus',
+  'MAPPING_2_TYPE' => 'integer',
+  'MAPPING_2_AGGREGATE_INTERVAL' => '5',
+}.freeze
+
 describe Mapper do
   subject(:mapper) { described_class.new(config:) }
 
@@ -787,6 +818,80 @@ describe Mapper do
         [
           { field: 'x', measurement: 'PV', value: 20 },
           { field: 'different', measurement: 'PV', value: 20 },
+        ],
+      )
+    end
+  end
+
+  context 'with MAPPING_X_AGGREGATE_INTERVAL' do
+    subject(:mapper) { described_class.new(config:) }
+
+    let(:config) { Config.new(AGGREGATE_ENV, logger:) }
+    let(:logger) { MemoryLogger.new }
+
+    def at(time)
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(time)
+    end
+
+    it 'does not affect a mapping without AGGREGATE_INTERVAL' do
+      at(1000.0)
+      hash = mapper.records_for('sensor/plain', '42')
+
+      expect(hash).to eq([{ field: 'plain_value', measurement: 'PV', value: 42 }])
+    end
+
+    it 'collects values without writing anything until the interval elapses' do
+      at(1000.0)
+      hash = mapper.records_for('sensor/fast', '10')
+      expect(hash).to eq([])
+
+      at(1002.0) # 2s later - still within the 5s window
+      hash = mapper.records_for('sensor/fast', '20')
+      expect(hash).to eq([])
+    end
+
+    it 'writes the average of all collected values once the interval elapses' do
+      at(1000.0)
+      mapper.records_for('sensor/fast', '10')
+
+      at(1002.0)
+      mapper.records_for('sensor/fast', '20')
+
+      at(1006.0) # 6s after the window started - beyond the 5s interval
+      hash = mapper.records_for('sensor/fast', '30')
+
+      # average of 10, 20, 30 == 20
+      expect(hash).to eq([{ field: 'fast_value', measurement: 'PV', value: 20 }])
+    end
+
+    it 'starts a fresh window after flushing, instead of carrying over old values' do
+      at(1000.0)
+      mapper.records_for('sensor/fast', '10')
+
+      at(1006.0)
+      mapper.records_for('sensor/fast', '20') # flushes average of [10, 20] == 15
+
+      at(1007.0) # new window just started - not yet due
+      hash = mapper.records_for('sensor/fast', '100')
+      expect(hash).to eq([])
+
+      at(1012.0) # 5s into the new window
+      hash = mapper.records_for('sensor/fast', '200')
+      expect(hash).to eq([{ field: 'fast_value', measurement: 'PV', value: 150 }])
+    end
+
+    it 'applies the aggregation before splitting into positive/negative fields' do
+      at(1000.0)
+      mapper.records_for('sensor/signed', '-10')
+
+      at(1006.0)
+      hash = mapper.records_for('sensor/signed', '30')
+
+      # average of -10 and 30 == 10 (positive)
+      expect(hash).to eq(
+        [
+          { field: 'signed_minus', measurement: 'PV', value: 0 },
+          { field: 'signed_plus', measurement: 'PV', value: 10 },
         ],
       )
     end


### PR DESCRIPTION
## Summary
- Add `MAPPING_X_AGGREGATE_INTERVAL` to throttle high-frequency topics down to one averaged write per interval
- Add `MAPPING_X_SKIP_WRITE` to keep a mapping's value tracked in memory (for `MAX_AGE`/virtual mapping formulas) without ever writing it to InfluxDB
- Make `FIELD`/`MEASUREMENT` optional for `SKIP_WRITE` mappings, since they're never used at runtime for those
- Add `MAPPING_X_DEDUP` to skip writing unchanged duplicate values, with a periodic heartbeat write to show the sender is still alive

Cherry-picked from `df503aa`, `26c8ec4`, `475933a`, `72fc5fc`, adapted onto this branch's existing named-mapping-reference refactor (the aggregation buffer's `mapping_key()` helper and the `SKIP_WRITE` virtual-mapping spec needed small adjustments to keep working with `MAPPING_X_NAME`-based references).

## Test plan
- [x] `bundle exec rspec` — 156 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkcJ7Dhuqx9vgo4s2kKwih)_