### PR TITLE
Queue MQTT records and retry InfluxDB writes on outage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Note: For a SENEC device there is a dedicated [senec-collector](https://github.c
 
 The Docker image supports multiple platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7`
 
+## Resilience against InfluxDB outages
+
+On startup, the collector waits (up to 12 seconds) for InfluxDB to become reachable before it starts subscribing to MQTT.
+
+While running, incoming MQTT messages are always received and converted immediately - they're never blocked by a slow or unreachable InfluxDB. Instead, they're queued in memory and written by a separate background process. If a write fails (e.g. because InfluxDB is temporarily unreachable), the batch stays queued and is retried automatically every 5 seconds, keeping its original measurement time - so once InfluxDB is reachable again, the backlog is delivered with the timestamps of when the values actually arrived, not when they were finally written.
+
+Note: this in-memory queue is lost if the container is restarted while InfluxDB is still unreachable.
+
 ## Development
 
 For development you need a recent Ruby setup. On a Mac, I recommend [rbenv](https://github.com/rbenv/rbenv).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ On startup, the collector waits (up to 12 seconds) for InfluxDB to become reacha
 
 While running, incoming MQTT messages are always received and converted immediately - they're never blocked by a slow or unreachable InfluxDB. Instead, they're queued in memory and written by a separate background process. If a write fails (e.g. because InfluxDB is temporarily unreachable), the batch stays queued and is retried automatically every 5 seconds, keeping its original measurement time - so once InfluxDB is reachable again, the backlog is delivered with the timestamps of when the values actually arrived, not when they were finally written.
 
+A batch that InfluxDB refuses outright is dropped instead of retried, because sending it again would produce the same answer. This applies to a broken line protocol (HTTP 400) and to a field that doesn't match the type it already has in InfluxDB (HTTP 422). Both are named in the log.
+
+The queue holds at most 100,000 batches - more than a day at one message per second. Beyond that, the oldest batch makes room for the newest one, so a very long outage costs the beginning of the backlog instead of the whole container.
+
+On shutdown (`docker stop` or Ctrl-C), the collector stops receiving MQTT messages first and then gives the queue up to 5 seconds to reach InfluxDB. That limit stays below the 10 seconds Docker allows before it kills the container. If InfluxDB is still unreachable when the time is up, the log says how many batches were lost.
+
 Note: this in-memory queue is lost if the container is restarted while InfluxDB is still unreachable.
 
 ## Development

--- a/lib/flux_writer.rb
+++ b/lib/flux_writer.rb
@@ -7,6 +7,10 @@ class FluxWriter
 
   attr_reader :config
 
+  def ready?
+    influx_client.ping.status == 'ok'
+  end
+
   def push(records, time:)
     write_api.write(
       data: points(records, time:),

--- a/lib/influx_push.rb
+++ b/lib/influx_push.rb
@@ -6,14 +6,23 @@ class InfluxPush
 
   def_delegators :config, :logger
 
-  def initialize(config:, retry_delay: 5)
+  # How long a shutdown waits for the queued batches to reach InfluxDB.
+  # It stays below the 10 seconds Docker gives a container before it sends
+  # SIGKILL, so the collector can report what it lost instead of being killed
+  # in the middle of the wait.
+  DEFAULT_SHUTDOWN_TIMEOUT = 5
+
+  def initialize(config:, retry_delay: 5, shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT)
     @config = config
     @retry_delay = retry_delay
+    @shutdown_timeout = shutdown_timeout
     @queue = Queue.new
+    @mutex = Mutex.new
+    @pending = 0
     @flux_writer = FluxWriter.new(config)
   end
 
-  attr_reader :config, :queue, :retry_delay, :flux_writer
+  attr_reader :config, :queue, :retry_delay, :shutdown_timeout, :flux_writer
 
   def ready?
     flux_writer.ready?
@@ -23,26 +32,41 @@ class InfluxPush
   # so a write delayed by a retry still lands at the point in time the values
   # were actually received.
   def enqueue(records:, time:)
-    queue << { records:, time: }
+    # The counter and the queue have to change together. A shutdown kills the
+    # thread that calls this, and a kill between the two steps would leave a
+    # batch counted but not queued. The count would never reach zero again.
+    Thread.handle_interrupt(Object => :never) do
+      change_pending(+1)
+      queue << { records:, time: }
+    end
   end
 
-  # Push batches from the queue to InfluxDB, one at a time, for as long as
-  # the queue is open. If InfluxDB is temporarily unreachable, the batch is
-  # put back into the queue and retried later instead of being dropped.
+  # How many batches have not reached InfluxDB yet: the ones waiting plus the
+  # one being written right now. A batch that goes back into the queue after a
+  # failed write stays counted, so this never reports progress that a retry
+  # can take back.
+  def pending
+    @mutex.synchronize { @pending }
+  end
+
+  # Push batches to InfluxDB, one at a time, until the queue is closed and
+  # empty. If InfluxDB is temporarily unreachable, the batch is put back into
+  # the queue and retried later instead of being dropped.
   def run
-    until queue.closed?
-      batch = queue.pop
-      push(batch) if batch
+    while (batch = queue.pop)
+      push(batch)
     end
   end
 
-  # Wait for the queue to drain, then close it so the run loop can finish
+  # Wait for the pending batches to reach InfluxDB, then stop the run loop.
+  #
+  # The wait is limited, because InfluxDB can still be unreachable - without
+  # a limit the retries would keep the process alive until it is killed, and
+  # the queue would be lost anyway. Whatever is left over is named in the log
+  # instead of disappearing silently.
   def shutdown
-    until queue.empty?
-      logger.info "Waiting for #{queue.size} batch(es) to be pushed to InfluxDB"
-      sleep 1
-    end
-
+    wait_for_pending
+    give_up
     queue.close
   end
 
@@ -50,23 +74,66 @@ class InfluxPush
 
   def push(batch)
     flux_writer.push(batch[:records], time: batch[:time])
+    change_pending(-1)
     logger.info "Successfully pushed #{batch[:records].size} record(s) " \
                 "from #{Time.at(batch[:time])} to InfluxDB"
   rescue StandardError => e
     error_handling(batch, e)
 
     # Wait a bit before trying again
-    sleep(retry_delay)
+    sleep(retry_delay) unless giving_up?
   end
 
   def error_handling(batch, error)
     logger.error "Error while pushing to InfluxDB: #{error.message}"
 
-    return if queue.closed?
+    # After the shutdown gave up, a retry can never reach InfluxDB. The
+    # shutdown already named how many batches are lost, so the batch is only
+    # counted out here.
+    return change_pending(-1) if giving_up?
 
     # Put the batch back into the queue, to retry later
     queue << batch
 
-    logger.info "The batch has been queued again. Will retry #{queue.size} batch(es) later."
+    logger.info "The batch has been queued again. Will retry #{pending} batch(es) later."
+  rescue ClosedQueueError
+    # The shutdown closed the queue while this batch was being written
+    logger.error "Dropping #{batch[:records].size} record(s) " \
+                 "from #{Time.at(batch[:time])} - they were never written to InfluxDB"
+    change_pending(-1)
+  end
+
+  def wait_for_pending
+    deadline = monotonic_time + shutdown_timeout
+
+    while pending.positive?
+      if monotonic_time >= deadline
+        logger.error "InfluxDB is still unreachable after #{shutdown_timeout} seconds - " \
+                     "giving up on #{pending} batch(es)"
+        return
+      end
+
+      logger.info "Waiting for #{pending} batch(es) to be pushed to InfluxDB"
+      sleep 1
+    end
+  end
+
+  # From here on a failed write is not retried anymore, so the run loop can
+  # finish instead of putting the batch back into a queue nobody drains.
+  def give_up
+    @mutex.synchronize { @giving_up = true }
+  end
+
+  def giving_up?
+    @mutex.synchronize { @giving_up }
+  end
+
+  def change_pending(delta)
+    @mutex.synchronize { @pending += delta }
+  end
+
+  # Not affected by a change of the system clock, unlike Time.now
+  def monotonic_time
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
   end
 end

--- a/lib/influx_push.rb
+++ b/lib/influx_push.rb
@@ -6,10 +6,10 @@ class InfluxPush
 
   def_delegators :config, :logger
 
-  def initialize(config:, queue:, retry_delay: 5)
+  def initialize(config:, retry_delay: 5)
     @config = config
-    @queue = queue
     @retry_delay = retry_delay
+    @queue = Queue.new
     @flux_writer = FluxWriter.new(config)
   end
 
@@ -19,16 +19,31 @@ class InfluxPush
     flux_writer.ready?
   end
 
+  # Hand a batch of records over to be written. The time travels with them,
+  # so a write delayed by a retry still lands at the point in time the values
+  # were actually received.
+  def enqueue(records:, time:)
+    queue << { records:, time: }
+  end
+
   # Push batches from the queue to InfluxDB, one at a time, for as long as
   # the queue is open. If InfluxDB is temporarily unreachable, the batch is
-  # put back into the queue and retried later instead of being dropped - it
-  # keeps its original measurement time, so a late write still lands at the
-  # point in time the values were actually received.
+  # put back into the queue and retried later instead of being dropped.
   def run
     until queue.closed?
       batch = queue.pop
       push(batch) if batch
     end
+  end
+
+  # Wait for the queue to drain, then close it so the run loop can finish
+  def shutdown
+    until queue.empty?
+      logger.info "Waiting for #{queue.size} batch(es) to be pushed to InfluxDB"
+      sleep 1
+    end
+
+    queue.close
   end
 
   private

--- a/lib/influx_push.rb
+++ b/lib/influx_push.rb
@@ -6,25 +6,52 @@ class InfluxPush
 
   def_delegators :config, :logger
 
-  def initialize(config:)
+  def initialize(config:, queue:, retry_delay: 5)
     @config = config
+    @queue = queue
+    @retry_delay = retry_delay
     @flux_writer = FluxWriter.new(config)
   end
 
-  attr_reader :config, :flux_writer
+  attr_reader :config, :queue, :retry_delay, :flux_writer
 
-  def call(records, time:, retries: nil, retry_delay: 5)
-    retry_count = 0
-    begin
-      flux_writer.push(records, time:)
-    rescue StandardError => e
-      logger.error "Error while pushing to InfluxDB: #{e.message}"
-      retry_count += 1
+  def ready?
+    flux_writer.ready?
+  end
 
-      raise e if retries && retry_count > retries
-
-      sleep(retry_delay)
-      retry
+  # Push batches from the queue to InfluxDB, one at a time, for as long as
+  # the queue is open. If InfluxDB is temporarily unreachable, the batch is
+  # put back into the queue and retried later instead of being dropped - it
+  # keeps its original measurement time, so a late write still lands at the
+  # point in time the values were actually received.
+  def run
+    until queue.closed?
+      batch = queue.pop
+      push(batch) if batch
     end
+  end
+
+  private
+
+  def push(batch)
+    flux_writer.push(batch[:records], time: batch[:time])
+    logger.info "Successfully pushed #{batch[:records].size} record(s) " \
+                "from #{Time.at(batch[:time])} to InfluxDB"
+  rescue StandardError => e
+    error_handling(batch, e)
+
+    # Wait a bit before trying again
+    sleep(retry_delay)
+  end
+
+  def error_handling(batch, error)
+    logger.error "Error while pushing to InfluxDB: #{error.message}"
+
+    return if queue.closed?
+
+    # Put the batch back into the queue, to retry later
+    queue << batch
+
+    logger.info "The batch has been queued again. Will retry #{queue.size} batch(es) later."
   end
 end

--- a/lib/influx_push.rb
+++ b/lib/influx_push.rb
@@ -12,11 +12,28 @@ class InfluxPush
   # in the middle of the wait.
   DEFAULT_SHUTDOWN_TIMEOUT = 5
 
+  # How long a retry waits while the collector shuts down. It is short, so the
+  # pending batches get more than one attempt inside the shutdown budget.
+  SHUTDOWN_RETRY_DELAY = 0.5
+
+  # InfluxDB refuses the data itself with these codes: the line protocol is
+  # broken (400), or a field does not match the type it already has (422). A
+  # retry sends the same data again, so such a batch would circle in the queue
+  # for as long as the collector runs.
+  UNACCEPTABLE_HTTP_CODES = %w[400 422].freeze
+
+  # The queue only lives in memory, so it cannot grow without a limit. A long
+  # outage would fill the memory until the container is killed, which loses
+  # the whole queue instead of its oldest part. At one message per second this
+  # holds more than a day.
+  MAX_QUEUE_SIZE = 100_000
+
   def initialize(config:, retry_delay: 5, shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT)
     @config = config
     @retry_delay = retry_delay
     @shutdown_timeout = shutdown_timeout
     @queue = Queue.new
+    @retry_wakeup = Queue.new
     @mutex = Mutex.new
     @pending = 0
     @flux_writer = FluxWriter.new(config)
@@ -36,6 +53,7 @@ class InfluxPush
     # thread that calls this, and a kill between the two steps would leave a
     # batch counted but not queued. The count would never reach zero again.
     Thread.handle_interrupt(Object => :never) do
+      drop_oldest if queue.size >= MAX_QUEUE_SIZE
       change_pending(+1)
       queue << { records:, time: }
     end
@@ -65,6 +83,7 @@ class InfluxPush
   # the queue would be lost anyway. Whatever is left over is named in the log
   # instead of disappearing silently.
   def shutdown
+    start_shutdown
     wait_for_pending
     give_up
     queue.close
@@ -78,10 +97,17 @@ class InfluxPush
     logger.info "Successfully pushed #{batch[:records].size} record(s) " \
                 "from #{Time.at(batch[:time])} to InfluxDB"
   rescue StandardError => e
-    error_handling(batch, e)
+    # Only a batch that waits for another attempt needs a pause. A pause after
+    # a dropped batch would hold up the whole queue for nothing.
+    wait_before_retry if error_handling(batch, e)
+  end
 
-    # Wait a bit before trying again
-    sleep(retry_delay) unless giving_up?
+  # Waits before the next attempt. A shutdown ends the wait at once, because
+  # sleeping through its whole budget would lose the batches it waits for.
+  def wait_before_retry
+    return sleep(SHUTDOWN_RETRY_DELAY) if shutting_down?
+
+    @retry_wakeup.pop(timeout: retry_delay)
   end
 
   def error_handling(batch, error)
@@ -90,17 +116,52 @@ class InfluxPush
     # After the shutdown gave up, a retry can never reach InfluxDB. The
     # shutdown already named how many batches are lost, so the batch is only
     # counted out here.
-    return change_pending(-1) if giving_up?
+    if giving_up?
+      change_pending(-1)
+      return false
+    end
+
+    if unacceptable?(error)
+      logger.error "InfluxDB refused #{batch[:records].size} record(s) " \
+                   "from #{Time.at(batch[:time])} - a retry sends the same data, " \
+                   'so the batch is dropped'
+      change_pending(-1)
+      return false
+    end
 
     # Put the batch back into the queue, to retry later
     queue << batch
 
     logger.info "The batch has been queued again. Will retry #{pending} batch(es) later."
+    true
   rescue ClosedQueueError
     # The shutdown closed the queue while this batch was being written
     logger.error "Dropping #{batch[:records].size} record(s) " \
                  "from #{Time.at(batch[:time])} - they were never written to InfluxDB"
     change_pending(-1)
+    false
+  end
+
+  # Keeps the newest data, because a dashboard shows the recent values first
+  def drop_oldest
+    queue.pop(true)
+    change_pending(-1)
+    warn_about_limit
+  rescue ThreadError
+    # The push thread took the batch first, so there is room again
+    nil
+  end
+
+  def warn_about_limit
+    return if @limit_reached
+
+    @limit_reached = true
+    logger.warn "The queue holds #{MAX_QUEUE_SIZE} batches, which is the limit. " \
+                'From now on the oldest batch is dropped for every new one.'
+  end
+
+  def unacceptable?(error)
+    error.is_a?(InfluxDB2::InfluxError) && UNACCEPTABLE_HTTP_CODES.include?(error.code)
   end
 
   def wait_for_pending
@@ -116,6 +177,17 @@ class InfluxPush
       logger.info "Waiting for #{pending} batch(es) to be pushed to InfluxDB"
       sleep 1
     end
+  end
+
+  # Wakes a retry that waits out its delay, so the pending batches are tried
+  # again right away instead of at the end of the shutdown
+  def start_shutdown
+    @mutex.synchronize { @shutting_down = true }
+    @retry_wakeup.close
+  end
+
+  def shutting_down?
+    @mutex.synchronize { @shutting_down }
   end
 
   # From here on a failed write is not retried anymore, so the run loop can

--- a/lib/loop.rb
+++ b/lib/loop.rb
@@ -30,7 +30,19 @@ class Loop
         receive_loop
       end
 
-    push_thread = Thread.new { push_loop }
+    push_thread =
+      Thread.new do
+        # Nobody joins this thread, so a fatal error in it would go unnoticed.
+        # The collector would keep filling the queue and drop every batch at
+        # the limit. Ending the process instead lets Docker restart it.
+        Thread.current.abort_on_exception = true
+
+        # The error reaches the main thread through the flag above, and Ruby
+        # reports it from there. A report here as well would only double it.
+        Thread.current.report_on_exception = false
+
+        push_loop
+      end
 
     # Wait for the receive thread to finish (will happen if max_count is set)
     receive_thread.join

--- a/lib/loop.rb
+++ b/lib/loop.rb
@@ -20,17 +20,29 @@ class Loop
   def start
     return unless influx_ready?
 
-    receive_thread = Thread.new { receive_loop }
+    receive_thread =
+      Thread.new do
+        # start joins this thread and logs what it raises, so the default
+        # report on stderr would only repeat it. The flag has to be set from
+        # inside, because the thread can raise before a caller reaches it.
+        Thread.current.report_on_exception = false
+
+        receive_loop
+      end
+
     push_thread = Thread.new { push_loop }
 
     # Wait for the receive thread to finish (will happen if max_count is set)
     receive_thread.join
-  rescue SystemExit, Interrupt
+  rescue SystemExit, SignalException
+    # Ctrl-C raises Interrupt, "docker stop" raises SignalException. Interrupt
+    # is one of those, so both arrive here and the ensure below does the work.
     logger.warn 'Exiting...'
-
-    # Stop receiving MQTT messages
-    receive_thread&.exit
   ensure
+    # Stop receiving MQTT messages first. Otherwise the queue keeps growing
+    # while it is drained, and the shutdown gives up on more than it had.
+    stop_receiving(receive_thread)
+
     # Push any remaining records to InfluxDB (can take a while, but not forever)
     influx_push.shutdown
 
@@ -106,19 +118,44 @@ class Loop
   def influx_ready?
     logger.info 'Wait until InfluxDB is ready ...'
 
-    count = 0
-    until (ready = influx_push.ready?) || (max_wait && count >= max_wait)
-      count += 1
-      sleep 1
-    end
+    started = monotonic_time
+    sleep 1 until (ready = influx_push.ready?) || waited_long_enough?(started)
 
     if ready
       logger.info 'InfluxDB is ready.'
       true
     else
-      logger.error "InfluxDB not ready after #{count} seconds - aborting."
+      waited = (monotonic_time - started).round
+      logger.error "InfluxDB not ready after #{waited} seconds - aborting."
       false
     end
+  end
+
+  # A ping can block for as long as the HTTP timeout, so the loop counts real
+  # seconds. Counting the attempts instead would report 12 seconds for a wait
+  # that took minutes.
+  def waited_long_enough?(started)
+    max_wait && monotonic_time - started >= max_wait
+  end
+
+  # Not affected by a change of the system clock, unlike Time.now
+  def monotonic_time
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  # Ends the receive thread and waits for it, so nothing reaches the queue
+  # after this point. Thread#kill alone only asks the thread to stop, and a
+  # message that arrives after that is counted but never written.
+  #
+  # Thread#join raises what the thread raised. start has already reported
+  # that, so it is ignored here.
+  def stop_receiving(thread)
+    return unless thread
+
+    thread.kill
+    thread.join(1)
+  rescue SignalException, StandardError
+    nil
   end
 
   # Push records from the queue to InfluxDB

--- a/lib/loop.rb
+++ b/lib/loop.rb
@@ -16,11 +16,8 @@ class Loop
   end
 
   attr_reader :config, :max_count, :retry_wait, :max_wait
-  attr_accessor :queue
 
   def start
-    self.queue = Queue.new
-
     return unless influx_ready?
 
     receive_thread = Thread.new { receive_loop }
@@ -28,20 +25,14 @@ class Loop
 
     # Wait for the receive thread to finish (will happen if max_count is set)
     receive_thread.join
-
-    # Push any remaining records to InfluxDB
-    close_queue
-
-    # Wait for the push thread to finish (will happen because queue is closed)
-    push_thread.join
   rescue SystemExit, Interrupt
     logger.warn 'Exiting...'
 
     # Stop receiving MQTT messages
     receive_thread&.exit
-
+  ensure
     # Push any remaining records to InfluxDB (can take a while)
-    close_queue
+    influx_push.shutdown
 
     # Stop pushing data to InfluxDB
     push_thread&.exit
@@ -80,7 +71,7 @@ class Loop
     count = 0
     loop do
       time, records = next_message
-      queue << { records:, time: time.to_i } if records.any?
+      influx_push.enqueue(records:, time: time.to_i) if records.any?
 
       count += 1
       break if max_count && count >= max_count
@@ -136,17 +127,7 @@ class Loop
   end
 
   def influx_push
-    @influx_push ||= InfluxPush.new(config:, queue:)
-  end
-
-  # Wait for the queue to drain, then close it so the push thread can finish
-  def close_queue
-    until queue.empty?
-      logger.info "Waiting for #{queue.size} batch(es) to be pushed to InfluxDB"
-      sleep 1
-    end
-
-    queue.close
+    @influx_push ||= InfluxPush.new(config:)
   end
 
   def mqtt_client

--- a/lib/loop.rb
+++ b/lib/loop.rb
@@ -31,7 +31,7 @@ class Loop
     # Stop receiving MQTT messages
     receive_thread&.exit
   ensure
-    # Push any remaining records to InfluxDB (can take a while)
+    # Push any remaining records to InfluxDB (can take a while, but not forever)
     influx_push.shutdown
 
     # Stop pushing data to InfluxDB

--- a/lib/loop.rb
+++ b/lib/loop.rb
@@ -8,15 +8,56 @@ class Loop
 
   def_delegators :config, :logger
 
-  def initialize(config:, retry_wait: 5, max_count: nil)
+  def initialize(config:, retry_wait: 5, max_count: nil, max_wait: 12)
     @config = config
     @max_count = max_count
     @retry_wait = retry_wait
+    @max_wait = max_wait
   end
 
-  attr_reader :config, :max_count, :retry_wait
+  attr_reader :config, :max_count, :retry_wait, :max_wait
+  attr_accessor :queue
 
   def start
+    self.queue = Queue.new
+
+    return unless influx_ready?
+
+    receive_thread = Thread.new { receive_loop }
+    push_thread = Thread.new { push_loop }
+
+    # Wait for the receive thread to finish (will happen if max_count is set)
+    receive_thread.join
+
+    # Push any remaining records to InfluxDB
+    close_queue
+
+    # Wait for the push thread to finish (will happen because queue is closed)
+    push_thread.join
+  rescue SystemExit, Interrupt
+    logger.warn 'Exiting...'
+
+    # Stop receiving MQTT messages
+    receive_thread&.exit
+
+    # Push any remaining records to InfluxDB (can take a while)
+    close_queue
+
+    # Stop pushing data to InfluxDB
+    push_thread&.exit
+  end
+
+  def stop
+    mqtt_client&.disconnect
+  rescue MQTT::ProtocolException, StandardError => e
+    handle_exception(e)
+  end
+
+  private
+
+  # Receive MQTT messages and add the resulting records to the queue, for
+  # InfluxPush to write - reconnects to the broker on error.
+  def receive_loop
     subscribe_topics
     receive_messages
   rescue MQTT::ProtocolException, StandardError => e
@@ -27,14 +68,6 @@ class Loop
     # Maybe use this gem: https://github.com/kamui/retriable
 
     retry if max_count.nil?
-  rescue SystemExit, Interrupt
-    logger.warn 'Exiting...'
-  end
-
-  def stop
-    mqtt_client&.disconnect
-  rescue MQTT::ProtocolException, StandardError => e
-    handle_exception(e)
   end
 
   def subscribe_topics
@@ -47,7 +80,7 @@ class Loop
     count = 0
     loop do
       time, records = next_message
-      influx_push.call(records, time: time.to_i) if records.any?
+      queue << { records:, time: time.to_i } if records.any?
 
       count += 1
       break if max_count && count >= max_count
@@ -57,7 +90,9 @@ class Loop
   def next_message
     topic, message = mqtt_client.get
 
-    # There is no timestamp in the MQTT message, so we use the current time
+    # There is no timestamp in the MQTT message, so we use the current time.
+    # This travels with the records through the queue, so a write that's
+    # delayed by a retry still lands at the time the message actually arrived.
     time = Time.now
 
     # Log all the data we received
@@ -76,8 +111,42 @@ class Loop
     [time, records]
   end
 
+  # Wait until InfluxDB is reachable, for up to max_wait seconds
+  def influx_ready?
+    logger.info 'Wait until InfluxDB is ready ...'
+
+    count = 0
+    until (ready = influx_push.ready?) || (max_wait && count >= max_wait)
+      count += 1
+      sleep 1
+    end
+
+    if ready
+      logger.info 'InfluxDB is ready.'
+      true
+    else
+      logger.error "InfluxDB not ready after #{count} seconds - aborting."
+      false
+    end
+  end
+
+  # Push records from the queue to InfluxDB
+  def push_loop
+    influx_push.run
+  end
+
   def influx_push
-    @influx_push ||= InfluxPush.new(config:)
+    @influx_push ||= InfluxPush.new(config:, queue:)
+  end
+
+  # Wait for the queue to drain, then close it so the push thread can finish
+  def close_queue
+    until queue.empty?
+      logger.info "Waiting for #{queue.size} batch(es) to be pushed to InfluxDB"
+      sleep 1
+    end
+
+    queue.close
   end
 
   def mqtt_client

--- a/spec/cassettes/influx_success.yml
+++ b/spec/cassettes/influx_success.yml
@@ -32,4 +32,34 @@ http_interactions:
       encoding: UTF-8
       string: ''
   recorded_at: Fri, 20 Sep 2024 06:04:21 GMT
+- request:
+    method: get
+    uri: http://localhost:8086/ping
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - influxdb-client-ruby/3.2.0
+      Authorization:
+      - Token my-token
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Influxdb-Build:
+      - OSS
+      X-Influxdb-Version:
+      - v2.8.0
+      Date:
+      - Fri, 27 Feb 2026 04:49:01 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Fri, 27 Feb 2026 04:49:01 GMT
 recorded_with: VCR 6.3.1

--- a/spec/lib/flux_writer_spec.rb
+++ b/spec/lib/flux_writer_spec.rb
@@ -1,0 +1,28 @@
+require 'flux_writer'
+require 'config'
+
+describe FluxWriter do
+  subject(:flux_writer) { described_class.new(config) }
+
+  let(:config) { Config.new(ENV, logger: MemoryLogger.new) }
+
+  describe '#ready?' do
+    it 'returns true when InfluxDB responds to ping', vcr: 'influx_success' do
+      expect(flux_writer.ready?).to be true
+    end
+
+    it 'returns false when InfluxDB is unreachable' do
+      stub_request(:get, 'http://localhost:8086/ping').to_raise(Errno::ECONNREFUSED)
+
+      expect(flux_writer.ready?).to be false
+    end
+  end
+
+  describe '#push' do
+    it 'writes the records to InfluxDB', vcr: 'influx_success' do
+      records = [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }]
+
+      expect { flux_writer.push(records, time: 1_726_812_261) }.not_to raise_error
+    end
+  end
+end

--- a/spec/lib/influx_push_spec.rb
+++ b/spec/lib/influx_push_spec.rb
@@ -83,6 +83,77 @@ describe InfluxPush do
     end
   end
 
+  describe 'an error InfluxDB will not accept' do
+    it 'drops the batch instead of retrying it forever' do
+      allow(FluxWriter).to receive(:new).and_return(failing_flux_writer(influx_error('422')))
+
+      influx_push.enqueue(records:, time:)
+
+      thread = Thread.new { influx_push.run }
+      Timeout.timeout(2) { sleep 0.01 until influx_push.pending.zero? }
+
+      expect(logger.error_messages).to include(/refused 1 record\(s\).*the batch is dropped/)
+      expect(influx_push.queue).to be_empty
+
+      influx_push.shutdown
+      thread.join
+    end
+
+    it 'drops without waiting, so the queue keeps moving' do
+      allow(FluxWriter).to receive(:new).and_return(failing_flux_writer(influx_error('422')))
+      influx_push = described_class.new(config:, retry_delay: 5)
+
+      3.times { |i| influx_push.enqueue(records:, time: i) }
+
+      thread = Thread.new { influx_push.run }
+      # A pause after each dropped batch would need 15 seconds for these three
+      Timeout.timeout(1) { sleep 0.01 until influx_push.pending.zero? }
+
+      influx_push.shutdown
+      expect(thread.join(2)).to eq(thread)
+    end
+
+    it 'keeps retrying a server error, which a retry can fix' do
+      allow(FluxWriter).to receive(:new).and_return(failing_flux_writer(influx_error('503')))
+
+      influx_push.enqueue(records:, time:)
+
+      thread = Thread.new { influx_push.run }
+      Timeout.timeout(2) { sleep 0.01 until logger.info_messages.any?(/queued again/) }
+
+      expect(influx_push.pending).to eq(1)
+
+      influx_push.queue.close
+      thread.exit
+    end
+  end
+
+  describe 'the queue limit' do
+    it 'drops the oldest batch instead of growing without a limit' do
+      stub_const('InfluxPush::MAX_QUEUE_SIZE', 3)
+
+      5.times { |i| influx_push.enqueue(records:, time: i) }
+
+      expect(influx_push.queue.size).to eq(3)
+      expect(influx_push.pending).to eq(3)
+      expect(logger.warn_messages).to include(/queue holds 3 batches, which is the limit/)
+
+      kept = Array.new(3) { influx_push.queue.pop[:time] }
+      expect(kept).to eq([2, 3, 4])
+    end
+
+    it 'keeps the batch when the push thread emptied the queue first' do
+      # A limit of 0 makes every enqueue look for a batch to drop, and finds
+      # none - the same situation as a push thread that was quicker
+      stub_const('InfluxPush::MAX_QUEUE_SIZE', 0)
+
+      expect { influx_push.enqueue(records:, time: 1) }.not_to raise_error
+
+      expect(influx_push.queue.size).to eq(1)
+      expect(influx_push.pending).to eq(1)
+    end
+  end
+
   describe '#pending' do
     it 'counts a batch until InfluxDB has accepted it' do
       writing = Queue.new
@@ -157,18 +228,45 @@ describe InfluxPush do
       expect(influx_push.pending).to eq(0)
     end
 
-    it 'gives up when InfluxDB stays unreachable, instead of waiting forever' do
-      influx_push = described_class.new(config:, retry_delay: 0.01, shutdown_timeout: 0)
-      allow(FluxWriter).to receive(:new).and_return(always_failing_flux_writer)
+    it 'retries at once instead of sleeping through its own budget' do
+      # The retry delay is as long as the shutdown budget. Without a wakeup the
+      # batch never gets its second attempt, and a healthy InfluxDB loses it.
+      attempts = 0
+      allow(FluxWriter).to receive(:new).and_return(
+        instance_double(FluxWriter).tap do |writer|
+          allow(writer).to receive(:push) do
+            attempts += 1
+            raise 'temporarily unreachable' if attempts == 1
+          end
+        end,
+      )
+      influx_push = described_class.new(config:, retry_delay: 5, shutdown_timeout: 5)
 
-      2.times { influx_push.enqueue(records:, time:) }
+      influx_push.enqueue(records:, time:)
+      thread = Thread.new { influx_push.run }
+      Timeout.timeout(2) { sleep 0.01 until attempts == 1 }
+
+      Timeout.timeout(3) { influx_push.shutdown }
+
+      expect(thread.join(2)).to eq(thread)
+      expect(attempts).to eq(2)
+      expect(influx_push.pending).to eq(0)
+      expect(logger.error_messages).not_to include(/giving up/)
+    end
+
+    it 'gives up when InfluxDB stays unreachable, instead of waiting forever' do
+      allow(FluxWriter).to receive(:new).and_return(always_failing_flux_writer)
+      influx_push = described_class.new(config:, retry_delay: 0.01, shutdown_timeout: 0)
+
+      20.times { influx_push.enqueue(records:, time:) }
 
       thread = Thread.new { influx_push.run }
       Timeout.timeout(2) { influx_push.shutdown }
 
+      # A pause after each dropped batch would need 10 seconds for these 20
       expect(thread.join(2)).to eq(thread)
       expect(logger.error_messages).to include(
-        /InfluxDB is still unreachable after 0 seconds - giving up on 2 batch\(es\)/,
+        /InfluxDB is still unreachable after 0 seconds - giving up on 20 batch\(es\)/,
       )
       expect(influx_push.pending).to eq(0)
     end
@@ -195,6 +293,16 @@ describe InfluxPush do
     thread = Thread.new { influx_push.run }
     Timeout.timeout(2) { influx_push.shutdown }
     thread.join
+  end
+
+  def influx_error(code)
+    InfluxDB2::InfluxError.new(message: "refused with #{code}", code:, reference: '', retry_after: '')
+  end
+
+  def failing_flux_writer(error)
+    instance_double(FluxWriter).tap do |writer|
+      allow(writer).to receive(:push).and_raise(error)
+    end
   end
 
   def always_failing_flux_writer

--- a/spec/lib/influx_push_spec.rb
+++ b/spec/lib/influx_push_spec.rb
@@ -1,37 +1,98 @@
+require 'timeout'
 require 'influx_push'
 require 'config'
 
 describe InfluxPush do
-  subject(:influx_push) { described_class.new(config:) }
+  subject(:influx_push) { described_class.new(config:, queue:, retry_delay: 0.1) }
 
-  let(:config) { Config.new(ENV, logger: MemoryLogger.new) }
+  let(:config) { Config.new(ENV, logger:) }
+  let(:logger) { MemoryLogger.new }
+  let(:queue) { Queue.new }
 
-  it 'initializes with a config' do
-    expect(influx_push.config).to eq(config)
+  describe '#ready?' do
+    it 'delegates to FluxWriter#ready?', vcr: 'influx_success' do
+      expect(influx_push.ready?).to be true
+    end
   end
 
-  it 'can push records to InfluxDB', vcr: 'influx_success' do
-    time = Time.now
-    records = [{ fields: { key: 'value' } }]
+  describe '#run' do
+    it 'pushes a single queued batch to InfluxDB', vcr: 'influx_success' do
+      queue << { records: [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }], time: 1_726_812_261 }
 
-    influx_push.call(records, time:)
+      run_until_drained
+
+      expect(logger.info_messages).to include(/Successfully pushed 1 record\(s\) from .* to InfluxDB/)
+      expect(logger.error_messages).to be_empty
+    end
+
+    it 'pushes multiple queued batches to InfluxDB', vcr: 'influx_success' do
+      2.times do
+        queue << { records: [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }], time: 1_726_812_261 }
+      end
+
+      run_until_drained
+
+      expect(logger.info_messages.grep(/Successfully pushed/).size).to eq(2)
+    end
+
+    it 'keeps retrying a batch that keeps failing, instead of dropping it' do
+      allow(FluxWriter).to receive(:new).and_return(always_failing_flux_writer)
+
+      batch = { records: [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }], time: 1_726_812_261 }
+      queue << batch
+
+      thread = Thread.new { influx_push.run }
+
+      expect { Timeout.timeout(0.5) { loop until queue.empty? } }.to raise_error(Timeout::Error)
+
+      expect(logger.error_messages).to include(/Error while pushing to InfluxDB: temporarily unreachable/)
+      expect(logger.info_messages).to include(/The batch has been queued again/)
+      expect(queue.size).to eq(1)
+
+      queue.close
+      thread.exit
+    end
+
+    it 'delivers a batch with its original timestamp once InfluxDB recovers' do
+      pushed = Queue.new
+      attempts = 0
+
+      allow(FluxWriter).to receive(:new).and_return(
+        instance_double(FluxWriter).tap do |writer|
+          allow(writer).to receive(:push) do |records, time:|
+            attempts += 1
+            raise 'temporarily unreachable' if attempts == 1
+
+            pushed << { records:, time: }
+          end
+        end,
+      )
+
+      original_time = 1_700_000_000
+      queue << { records: [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }], time: original_time }
+
+      thread = Thread.new { influx_push.run }
+
+      delivered = Timeout.timeout(2) { pushed.pop }
+      queue.close
+      thread.join
+
+      expect(delivered[:time]).to eq(original_time)
+      expect(logger.error_messages).to include(/Error while pushing to InfluxDB: temporarily unreachable/)
+      expect(logger.info_messages).to include(/Successfully pushed 1 record\(s\)/)
+    end
   end
 
-  it 'can handle error' do
-    fake_flux = instance_double(FluxWriter)
-    allow(fake_flux).to receive(:push).and_raise(StandardError)
-    allow(FluxWriter).to receive(:new).and_return(fake_flux)
+  def run_until_drained
+    thread = Thread.new { influx_push.run }
+    Timeout.timeout(2) { sleep 0.01 until queue.empty? }
+    queue.close
+    thread.join
+  end
 
-    time = Time.now
-    records = [{ fields: { key: 'value' } }]
-
-    expect do
-      influx_push.call(records, time:, retries: 1, retry_delay: 0.1)
-    end.to raise_error(StandardError)
-
-    expect(config.logger.error_messages).to include(
-      'Error while pushing to InfluxDB: StandardError',
-    )
-    sleep(1)
+  def always_failing_flux_writer
+    instance_double(FluxWriter).tap do |writer|
+      allow(writer).to receive(:push).and_raise('temporarily unreachable')
+    end
   end
 end

--- a/spec/lib/influx_push_spec.rb
+++ b/spec/lib/influx_push_spec.rb
@@ -41,13 +41,13 @@ describe InfluxPush do
 
       thread = Thread.new { influx_push.run }
 
-      expect { Timeout.timeout(0.5) { sleep 0.01 until influx_push.queue.empty? } }.to raise_error(
+      expect { Timeout.timeout(0.5) { sleep 0.01 until influx_push.pending.zero? } }.to raise_error(
         Timeout::Error,
       )
 
       expect(logger.error_messages).to include(/Error while pushing to InfluxDB: temporarily unreachable/)
       expect(logger.info_messages).to include(/The batch has been queued again/)
-      expect(influx_push.queue.size).to eq(1)
+      expect(influx_push.pending).to eq(1)
 
       influx_push.queue.close
       thread.exit
@@ -83,27 +83,111 @@ describe InfluxPush do
     end
   end
 
+  describe '#pending' do
+    it 'counts a batch until InfluxDB has accepted it' do
+      writing = Queue.new
+      finish = Queue.new
+
+      allow(FluxWriter).to receive(:new).and_return(
+        instance_double(FluxWriter).tap do |writer|
+          allow(writer).to receive(:push) do
+            writing << true
+            finish.pop
+          end
+        end,
+      )
+
+      expect(influx_push.pending).to eq(0)
+
+      influx_push.enqueue(records:, time:)
+      expect(influx_push.pending).to eq(1)
+
+      thread = Thread.new { influx_push.run }
+
+      # The batch has left the queue, but is not written yet
+      Timeout.timeout(2) { writing.pop }
+      expect(influx_push.queue).to be_empty
+      expect(influx_push.pending).to eq(1)
+
+      finish << true
+      Timeout.timeout(2) { sleep 0.01 until influx_push.pending.zero? }
+
+      influx_push.shutdown
+      thread.join
+    end
+  end
+
+  describe '#enqueue' do
+    it 'keeps the count and the queue in step when the caller is killed' do
+      # A shutdown kills the MQTT thread while it may sit inside enqueue
+      20.times do
+        push = described_class.new(config:)
+        producer = Thread.new { loop { push.enqueue(records:, time:) } }
+        sleep 0.002
+        producer.kill
+        producer.join
+
+        expect(push.pending).to eq(push.queue.size)
+      end
+    end
+  end
+
   describe '#shutdown' do
     it 'ends the run loop once everything is written', vcr: 'influx_success' do
       influx_push.enqueue(records:, time:)
 
       thread = Thread.new { influx_push.run }
-      Timeout.timeout(5) { influx_push.shutdown }
+      Timeout.timeout(2) { influx_push.shutdown }
 
       expect(thread.join(2)).to eq(thread)
+      expect(influx_push.pending).to eq(0)
       expect(logger.error_messages).to be_empty
     end
 
-    it 'logs progress while waiting for the queue to drain' do
+    it 'waits for the pending batches and says how many are left' do
       allow(FluxWriter).to receive(:new).and_return(slow_flux_writer)
 
-      3.times { influx_push.enqueue(records:, time:) }
+      influx_push.enqueue(records:, time:)
 
       thread = Thread.new { influx_push.run }
       Timeout.timeout(5) { influx_push.shutdown }
       thread.join
 
-      expect(logger.info_messages).to include(/Waiting for \d batch\(es\) to be pushed to InfluxDB/)
+      expect(logger.info_messages).to include(/Waiting for 1 batch\(es\) to be pushed to InfluxDB/)
+      expect(influx_push.pending).to eq(0)
+    end
+
+    it 'gives up when InfluxDB stays unreachable, instead of waiting forever' do
+      influx_push = described_class.new(config:, retry_delay: 0.01, shutdown_timeout: 0)
+      allow(FluxWriter).to receive(:new).and_return(always_failing_flux_writer)
+
+      2.times { influx_push.enqueue(records:, time:) }
+
+      thread = Thread.new { influx_push.run }
+      Timeout.timeout(2) { influx_push.shutdown }
+
+      expect(thread.join(2)).to eq(thread)
+      expect(logger.error_messages).to include(
+        /InfluxDB is still unreachable after 0 seconds - giving up on 2 batch\(es\)/,
+      )
+      expect(influx_push.pending).to eq(0)
+    end
+
+    it 'reports a batch that fails while the queue is being closed' do
+      allow(FluxWriter).to receive(:new).and_return(always_failing_flux_writer)
+
+      influx_push.enqueue(records:, time:)
+
+      # The shutdown closes the queue while this batch is being written
+      allow(influx_push.queue).to receive(:<<).and_raise(ClosedQueueError)
+
+      thread = Thread.new { influx_push.run }
+      Timeout.timeout(2) { sleep 0.01 until influx_push.pending.zero? }
+
+      expect(logger.error_messages).to include(/Dropping 1 record\(s\).*never written to InfluxDB/)
+
+      influx_push.shutdown
+      expect(thread.join(2)).to eq(thread)
     end
   end
 

--- a/spec/lib/influx_push_spec.rb
+++ b/spec/lib/influx_push_spec.rb
@@ -3,11 +3,12 @@ require 'influx_push'
 require 'config'
 
 describe InfluxPush do
-  subject(:influx_push) { described_class.new(config:, queue:, retry_delay: 0.1) }
+  subject(:influx_push) { described_class.new(config:, retry_delay: 0.1) }
 
   let(:config) { Config.new(ENV, logger:) }
   let(:logger) { MemoryLogger.new }
-  let(:queue) { Queue.new }
+  let(:records) { [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }] }
+  let(:time) { 1_726_812_261 }
 
   describe '#ready?' do
     it 'delegates to FluxWriter#ready?', vcr: 'influx_success' do
@@ -17,7 +18,7 @@ describe InfluxPush do
 
   describe '#run' do
     it 'pushes a single queued batch to InfluxDB', vcr: 'influx_success' do
-      queue << { records: [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }], time: 1_726_812_261 }
+      influx_push.enqueue(records:, time:)
 
       run_until_drained
 
@@ -26,9 +27,7 @@ describe InfluxPush do
     end
 
     it 'pushes multiple queued batches to InfluxDB', vcr: 'influx_success' do
-      2.times do
-        queue << { records: [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }], time: 1_726_812_261 }
-      end
+      2.times { influx_push.enqueue(records:, time:) }
 
       run_until_drained
 
@@ -38,18 +37,19 @@ describe InfluxPush do
     it 'keeps retrying a batch that keeps failing, instead of dropping it' do
       allow(FluxWriter).to receive(:new).and_return(always_failing_flux_writer)
 
-      batch = { records: [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }], time: 1_726_812_261 }
-      queue << batch
+      influx_push.enqueue(records:, time:)
 
       thread = Thread.new { influx_push.run }
 
-      expect { Timeout.timeout(0.5) { loop until queue.empty? } }.to raise_error(Timeout::Error)
+      expect { Timeout.timeout(0.5) { sleep 0.01 until influx_push.queue.empty? } }.to raise_error(
+        Timeout::Error,
+      )
 
       expect(logger.error_messages).to include(/Error while pushing to InfluxDB: temporarily unreachable/)
       expect(logger.info_messages).to include(/The batch has been queued again/)
-      expect(queue.size).to eq(1)
+      expect(influx_push.queue.size).to eq(1)
 
-      queue.close
+      influx_push.queue.close
       thread.exit
     end
 
@@ -69,12 +69,12 @@ describe InfluxPush do
       )
 
       original_time = 1_700_000_000
-      queue << { records: [{ measurement: 'PV', field: 'battery_soc', value: 80.0 }], time: original_time }
+      influx_push.enqueue(records:, time: original_time)
 
       thread = Thread.new { influx_push.run }
 
       delivered = Timeout.timeout(2) { pushed.pop }
-      queue.close
+      influx_push.shutdown
       thread.join
 
       expect(delivered[:time]).to eq(original_time)
@@ -83,16 +83,46 @@ describe InfluxPush do
     end
   end
 
+  describe '#shutdown' do
+    it 'ends the run loop once everything is written', vcr: 'influx_success' do
+      influx_push.enqueue(records:, time:)
+
+      thread = Thread.new { influx_push.run }
+      Timeout.timeout(5) { influx_push.shutdown }
+
+      expect(thread.join(2)).to eq(thread)
+      expect(logger.error_messages).to be_empty
+    end
+
+    it 'logs progress while waiting for the queue to drain' do
+      allow(FluxWriter).to receive(:new).and_return(slow_flux_writer)
+
+      3.times { influx_push.enqueue(records:, time:) }
+
+      thread = Thread.new { influx_push.run }
+      Timeout.timeout(5) { influx_push.shutdown }
+      thread.join
+
+      expect(logger.info_messages).to include(/Waiting for \d batch\(es\) to be pushed to InfluxDB/)
+    end
+  end
+
   def run_until_drained
     thread = Thread.new { influx_push.run }
-    Timeout.timeout(2) { sleep 0.01 until queue.empty? }
-    queue.close
+    Timeout.timeout(2) { influx_push.shutdown }
     thread.join
   end
 
   def always_failing_flux_writer
     instance_double(FluxWriter).tap do |writer|
       allow(writer).to receive(:push).and_raise('temporarily unreachable')
+    end
+  end
+
+  # Takes long enough that the shutdown has to wait a round for it
+  def slow_flux_writer
+    instance_double(FluxWriter).tap do |writer|
+      allow(writer).to receive(:push) { sleep 0.5 }
     end
   end
 end

--- a/spec/lib/loop_spec.rb
+++ b/spec/lib/loop_spec.rb
@@ -2,7 +2,7 @@ require 'loop'
 require 'config'
 
 describe Loop do
-  subject(:loop) { described_class.new(config:, max_count: 1, retry_wait: 1) }
+  let(:loop) { described_class.new(config:, max_count: 1, retry_wait: 1) }
 
   let(:config) do
     Config.new(
@@ -37,6 +37,8 @@ describe Loop do
     end
 
     context 'when the MQTT server is not running' do
+      before { allow(loop).to receive(:influx_ready?).and_return(true) }
+
       it 'handles errors' do
         loop.start
 
@@ -49,12 +51,69 @@ describe Loop do
     end
 
     context 'when interrupted' do
-      before { allow(MQTT::Client).to receive(:new).and_raise(Interrupt) }
+      before do
+        allow(loop).to receive(:influx_ready?).and_return(true)
+        allow(MQTT::Client).to receive(:new).and_raise(Interrupt)
+      end
 
       it 'handles interruption' do
         loop.start
 
         expect(logger.warn_messages).to include(/Exiting/)
+      end
+    end
+
+    context 'when InfluxDB is not ready' do
+      let(:loop) { described_class.new(config:, max_count: 1, max_wait: 0) }
+      let(:config) { Config.new(ENV.to_h, logger:) }
+
+      it 'aborts without ever subscribing to MQTT' do
+        stub_request(:get, 'http://localhost:8086/ping').to_raise(Errno::ECONNREFUSED)
+        allow(MQTT::Client).to receive(:connect)
+
+        loop.start
+
+        expect(MQTT::Client).not_to have_received(:connect)
+        expect(logger.error_messages).to include(/InfluxDB not ready after 0 seconds - aborting/)
+      end
+    end
+
+    context 'when InfluxDB becomes ready only after retrying' do
+      before do
+        allow(loop).to receive(:sleep)
+        allow(loop).to receive(:receive_loop)
+        allow(loop).to receive(:push_loop)
+
+        fake_influx_push = instance_double(InfluxPush)
+        allow(fake_influx_push).to receive(:ready?).and_return(false, true)
+        allow(loop).to receive(:influx_push).and_return(fake_influx_push)
+      end
+
+      it 'waits and retries the readiness check before continuing' do
+        loop.start
+
+        expect(logger.info_messages).to include(/Wait until InfluxDB is ready/)
+        expect(logger.info_messages).to include(/InfluxDB is ready/)
+      end
+    end
+
+    context 'when the queue takes a moment to drain' do
+      before do
+        allow(loop).to receive(:sleep)
+        allow(loop).to receive(:influx_ready?).and_return(true)
+        allow(loop).to receive(:receive_loop)
+        allow(loop).to receive(:push_loop)
+
+        fake_queue = Queue.new
+        fake_queue << { records: [], time: 0 }
+        allow(fake_queue).to receive(:empty?).and_return(false, true)
+        allow(Queue).to receive(:new).and_return(fake_queue)
+      end
+
+      it 'logs progress while waiting for the queue to drain' do
+        loop.start
+
+        expect(logger.info_messages).to include(/Waiting for 1 batch\(es\) to be pushed to InfluxDB/)
       end
     end
   end

--- a/spec/lib/loop_spec.rb
+++ b/spec/lib/loop_spec.rb
@@ -126,6 +126,19 @@ describe Loop do
       end
     end
 
+    context 'when the push thread dies unexpectedly' do
+      before do
+        allow(loop).to receive_messages(influx_ready?: true,
+                                        influx_push: instance_double(InfluxPush, shutdown: nil),)
+        allow(loop).to receive(:receive_loop) { sleep 2 }
+        allow(loop).to receive(:push_loop).and_raise('the push thread is broken')
+      end
+
+      it 'ends instead of running on without a writer' do
+        expect { loop.start }.to raise_error('the push thread is broken')
+      end
+    end
+
     context 'when shutting down' do
       before do
         allow(loop).to receive_messages(influx_ready?: true, influx_push: fake_influx_push)

--- a/spec/lib/loop_spec.rb
+++ b/spec/lib/loop_spec.rb
@@ -63,6 +63,21 @@ describe Loop do
       end
     end
 
+    context 'when terminated by a signal' do
+      before do
+        allow(loop).to receive(:influx_ready?).and_return(true)
+        # "docker stop" sends SIGTERM, which raises SignalException and not
+        # Interrupt
+        allow(MQTT::Client).to receive(:new).and_raise(SignalException, 'TERM')
+      end
+
+      it 'shuts down like an interrupt' do
+        loop.start
+
+        expect(logger.warn_messages).to include(/Exiting/)
+      end
+    end
+
     context 'when InfluxDB is not ready' do
       let(:loop) { described_class.new(config:, max_count: 1, max_wait: 0) }
       let(:config) { Config.new(ENV.to_h, logger:) }
@@ -75,6 +90,19 @@ describe Loop do
 
         expect(MQTT::Client).not_to have_received(:connect)
         expect(logger.error_messages).to include(/InfluxDB not ready after 0 seconds - aborting/)
+      end
+    end
+
+    context 'when a readiness check blocks' do
+      it 'reports the seconds it really waited, not the number of attempts' do
+        fake_influx_push = instance_double(InfluxPush, shutdown: nil, ready?: false)
+        allow(loop).to receive(:influx_push).and_return(fake_influx_push)
+        # A single attempt that blocks for 30 seconds, as an HTTP timeout does
+        allow(loop).to receive(:monotonic_time).and_return(0, 30, 30)
+
+        loop.start
+
+        expect(logger.error_messages).to include(/InfluxDB not ready after 30 seconds - aborting/)
       end
     end
 

--- a/spec/lib/loop_spec.rb
+++ b/spec/lib/loop_spec.rb
@@ -84,10 +84,11 @@ describe Loop do
         allow(loop).to receive(:receive_loop)
         allow(loop).to receive(:push_loop)
 
-        fake_influx_push = instance_double(InfluxPush)
-        allow(fake_influx_push).to receive(:ready?).and_return(false, true)
         allow(loop).to receive(:influx_push).and_return(fake_influx_push)
+        allow(fake_influx_push).to receive(:ready?).and_return(false, true)
       end
+
+      let(:fake_influx_push) { instance_double(InfluxPush, shutdown: nil) }
 
       it 'waits and retries the readiness check before continuing' do
         loop.start
@@ -97,23 +98,19 @@ describe Loop do
       end
     end
 
-    context 'when the queue takes a moment to drain' do
+    context 'when shutting down' do
       before do
-        allow(loop).to receive(:sleep)
-        allow(loop).to receive(:influx_ready?).and_return(true)
+        allow(loop).to receive_messages(influx_ready?: true, influx_push: fake_influx_push)
         allow(loop).to receive(:receive_loop)
         allow(loop).to receive(:push_loop)
-
-        fake_queue = Queue.new
-        fake_queue << { records: [], time: 0 }
-        allow(fake_queue).to receive(:empty?).and_return(false, true)
-        allow(Queue).to receive(:new).and_return(fake_queue)
       end
 
-      it 'logs progress while waiting for the queue to drain' do
+      let(:fake_influx_push) { instance_double(InfluxPush, shutdown: nil) }
+
+      it 'lets InfluxPush write what is left before ending' do
         loop.start
 
-        expect(logger.info_messages).to include(/Waiting for 1 batch\(es\) to be pushed to InfluxDB/)
+        expect(fake_influx_push).to have_received(:shutdown)
       end
     end
   end


### PR DESCRIPTION
Previously, a failed InfluxDB write blocked the whole MQTT receive loop with a synchronous sleep-and-retry, risking broker disconnects and message loss during an outage. Following the same pattern already used in senec-collector and shelly-collector, receiving and writing are now decoupled via a queue and separate threads:

- Loop waits (up to max_wait seconds) for InfluxDB to be reachable before subscribing to MQTT.
- Incoming messages are always received and converted immediately, then enqueued together with their original timestamp - never blocked by a slow or unreachable InfluxDB.
- A background thread continuously pops batches off the queue and writes them; on failure, the batch is put back on the queue and retried after a delay, keeping its original timestamp so a delayed write still lands at the correct point in time.
- On shutdown, the queue is drained (with progress logging) before the process exits, so no already-received data is lost.

FluxWriter gained a ready?/ping check, matching the sibling collectors.

Closes #268